### PR TITLE
NEO-1075: LeffNav->TopLink: Active state is now driven by currentUrl value

### DIFF
--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: TopLinkItem,
 } as Meta<TopLinkItemProps>;
 const handleClick = (id: string, url: string) => {
-  alert(`clicked on the item with id: ${id}, url: ${url}`);
+  window.open(url);
 };
 export const Default = () => (
   <LeftNavigation
@@ -17,11 +17,11 @@ export const Default = () => (
     currentUrl="#active"
   >
     <TopLinkItem label="Active by default" href="#active" />
-    <TopLinkItem label="Normal Link" href="#normal" />
+    <TopLinkItem label="Link to Google" href="http://google.com" />
     <TopLinkItem
-      label="Normal Link with Icon"
+      label="Link with Icon to Bing"
       icon="address-book"
-      href="#icon"
+      href="http://bing.com"
     />
     <TopLinkItem label="Disabled Link" disabled href="#disabled" />
     <TopLinkItem

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
@@ -14,23 +14,21 @@ export const Default = () => (
   <LeftNavigation
     aria-label="Main Navigation"
     onNavigate={handleClick}
-    currentUrl=""
+    currentUrl="#active"
   >
-    <TopLinkItem label="Normal Link" href="#" />
-    <TopLinkItem active label="Active Link" href="#" />
-    <TopLinkItem label="Normal Link with Icon" icon="address-book" href="#" />
+    <TopLinkItem label="Active by default" href="#active" />
+    <TopLinkItem label="Normal Link" href="#normal" />
     <TopLinkItem
-      active
-      label="Active Link with Icon"
+      label="Normal Link with Icon"
       icon="address-book"
-      href="#"
+      href="#icon"
     />
-    <TopLinkItem label="Disabled Link" disabled href="#" />
+    <TopLinkItem label="Disabled Link" disabled href="#disabled" />
     <TopLinkItem
       label="Disabled Link with Icon"
       icon="address-book"
       disabled
-      href="#"
+      href="#disabledicon"
     />
   </LeftNavigation>
 );

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.test.jsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.test.jsx
@@ -31,7 +31,11 @@ describe("TopLinkItem", () => {
   });
 
   it("assigns the appropriate class name when the `active` prop is passed", () => {
-    render(<TopLinkItem label={TopLinkItemLabel} active />);
+    render(
+      <LeftNavigation currentUrl="#test">
+        <TopLinkItem href="#test" label={TopLinkItemLabel} />
+      </LeftNavigation>
+    );
     const linkElement = screen.getByRole("listitem");
     expect(linkElement).toHaveClass("neo-leftnav__main--active");
   });

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.tsx
@@ -34,7 +34,7 @@ export const TopLinkItem = ({
 
   useEffect(() => {
     setIsActive(href === ctx.currentUrl);
-  }, [ctx.currentUrl]);
+  }, [ctx.currentUrl, isActive, href]);
 
   const onClick: MouseEventHandler = (e) => {
     e.preventDefault();

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.tsx
@@ -1,5 +1,11 @@
 import clsx from "clsx";
-import { MouseEventHandler, useContext, useId } from "react";
+import {
+  MouseEventHandler,
+  useContext,
+  useEffect,
+  useId,
+  useState,
+} from "react";
 
 import { Button } from "components/Button";
 import { IconNamesType } from "utils";
@@ -9,7 +15,6 @@ import { NavigationContext } from "../NavigationContext";
 import "./TopLinkItem_shim.css";
 
 export interface TopLinkItemProps {
-  active?: boolean;
   label: string;
   href: string;
   icon?: IconNamesType;
@@ -18,7 +23,6 @@ export interface TopLinkItemProps {
 }
 
 export const TopLinkItem = ({
-  active,
   label,
   href,
   icon,
@@ -26,6 +30,11 @@ export const TopLinkItem = ({
   disabled,
 }: TopLinkItemProps) => {
   const ctx = useContext(NavigationContext);
+  const [isActive, setIsActive] = useState(false);
+
+  useEffect(() => {
+    setIsActive(href === ctx.currentUrl);
+  }, [ctx.currentUrl]);
 
   const onClick: MouseEventHandler = (e) => {
     e.preventDefault();
@@ -36,7 +45,7 @@ export const TopLinkItem = ({
     <li
       className={clsx(
         "neo-leftnav__main",
-        active && "neo-leftnav__main--active"
+        isActive && "neo-leftnav__main--active"
       )}
     >
       {disabled ? (


### PR DESCRIPTION
**Before tagging the team for a review, I have done the following:**
- [x ] reviewed my code changes
- [x] ensured that all tests pass
- [x ] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x ] done an accessibility check on my work

We now update the TopLink active state if the currentUrl matches the url for that TopLinkItem

![2022-08-22 14 24 34](https://user-images.githubusercontent.com/3535271/186021868-9abb4ab8-3607-4e09-b159-29f75b6eb026.gif)




