### PR TITLE
NEO-1077 & NEO-1076: Center InfoModal/BasicModal component when it pops up

### DIFF
--- a/src/components/Modal/BasicModal/BasicModal.tsx
+++ b/src/components/Modal/BasicModal/BasicModal.tsx
@@ -1,6 +1,7 @@
-import { ReactNode, useCallback, useEffect } from "react";
+import { ReactNode, useCallback, useEffect, forwardRef, useId } from "react";
 import ReactDOM from "react-dom";
 import FocusLock from "react-focus-lock";
+import clsx from "clsx";
 
 import { Button, ButtonProps } from "components/Button";
 
@@ -15,57 +16,71 @@ export interface BasicModalProps extends ButtonProps {
   title: string;
 }
 
-export const BasicModal = ({
-  children,
-  closeButtonLabel = "Close",
-  onClose,
-  open,
-  title,
-  ...rest
-}: BasicModalProps) => {
-  const buttons = "actions" in rest ? rest.actions : null;
+export const BasicModal = forwardRef(
+  (
+    {
+      className,
+      children,
+      closeButtonLabel = "Close",
+      onClose,
+      open,
+      title,
+      id = useId(),
+      ...rest
+    }: BasicModalProps,
+    ref: React.Ref<HTMLButtonElement>
+  ) => {
+    const buttons = "actions" in rest ? rest.actions : null;
 
-  const onKeyDown = useCallback(
-    (e: { key: string }) => {
-      if (e.key === "Escape" && open) {
-        onClose();
-      }
-    },
-    [open]
-  );
+    const onKeyDown = useCallback(
+      (e: { key: string }) => {
+        if (e.key === "Escape" && open) {
+          onClose();
+        }
+      },
+      [open]
+    );
 
-  useEffect(() => {
-    document.addEventListener("keyup", onKeyDown, false);
-    return () => {
-      document.removeEventListener("keyup", onKeyDown, false);
-    };
-  }, [open]);
+    useEffect(() => {
+      document.addEventListener("keyup", onKeyDown, false);
+      return () => {
+        document.removeEventListener("keyup", onKeyDown, false);
+      };
+    }, [open]);
 
-  const modal = (
-    <FocusLock>
-      <div id="neo-modal-example" className="neo-modal--active">
-        <div className="neo-modal__background"></div>
-        <div
-          className="neo-modal__content"
-          aria-modal="true"
-          aria-labelledby={title}
-          role="dialog"
-        >
-          <div className="neo-modal__header">
-            <h4>{title}</h4>
-          </div>
-          <div className="neo-modal__body">
-            <div className="neo-modal__message">{children}</div>
-          </div>
-          <div className="neo-modal__footer">
-            <Button variant="secondary" data-dismiss="modal" onClick={onClose}>
-              {closeButtonLabel}
-            </Button>
-            {buttons}
+    const modal = (
+      <FocusLock>
+        <div id={id} className={clsx("neo-modal--active", className)}>
+          <div className="neo-modal__background"></div>
+          <div
+            className="neo-modal__content"
+            aria-modal="true"
+            aria-labelledby={title}
+            role="dialog"
+          >
+            <div className="neo-modal__header">
+              <h4>{title}</h4>
+            </div>
+            <div className="neo-modal__body">
+              <div className="neo-modal__message">{children}</div>
+            </div>
+            <div className="neo-modal__footer">
+              <Button
+                variant="secondary"
+                data-dismiss="modal"
+                onClick={onClose}
+                ref={ref}
+              >
+                {closeButtonLabel}
+              </Button>
+              {buttons}
+            </div>
           </div>
         </div>
-      </div>
-    </FocusLock>
-  );
-  return open ? ReactDOM.createPortal(modal, document.body) : null;
-};
+      </FocusLock>
+    );
+    return open ? ReactDOM.createPortal(modal, document.body) : null;
+  }
+);
+
+BasicModal.displayName = "Basic Modal";

--- a/src/components/Modal/BasicModal/BasicModal.tsx
+++ b/src/components/Modal/BasicModal/BasicModal.tsx
@@ -83,4 +83,4 @@ export const BasicModal = forwardRef(
   }
 );
 
-BasicModal.displayName = "Basic Modal";
+BasicModal.displayName = "BasicModal";

--- a/src/components/Modal/BasicModal/BasicModal.tsx
+++ b/src/components/Modal/BasicModal/BasicModal.tsx
@@ -3,17 +3,19 @@ import ReactDOM from "react-dom";
 import FocusLock from "react-focus-lock";
 import clsx from "clsx";
 
-import { Button, ButtonProps } from "components/Button";
+import { Button } from "components/Button";
 
 import "./BasicModal_shim.css";
 
-export interface BasicModalProps extends ButtonProps {
+export interface BasicModalProps {
   actions?: JSX.Element[];
   children?: ReactNode;
   closeButtonLabel?: string;
   onClose: () => void;
   open: boolean;
   title: string;
+  className?: string;
+  id?: string;
 }
 
 export const BasicModal = forwardRef(
@@ -28,7 +30,7 @@ export const BasicModal = forwardRef(
       id = useId(),
       ...rest
     }: BasicModalProps,
-    ref: React.Ref<HTMLButtonElement>
+    ref: React.Ref<HTMLDivElement>
   ) => {
     const buttons = "actions" in rest ? rest.actions : null;
 
@@ -50,7 +52,7 @@ export const BasicModal = forwardRef(
 
     const modal = (
       <FocusLock>
-        <div id={id} className={clsx("neo-modal--active", className)}>
+        <div ref={ref} id={id} className={clsx("neo-modal--active", className)}>
           <div className="neo-modal__background"></div>
           <div
             className="neo-modal__content"
@@ -69,7 +71,6 @@ export const BasicModal = forwardRef(
                 variant="secondary"
                 data-dismiss="modal"
                 onClick={onClose}
-                ref={ref}
               >
                 {closeButtonLabel}
               </Button>

--- a/src/components/Modal/BasicModal/BasicModal_shim.css
+++ b/src/components/Modal/BasicModal/BasicModal_shim.css
@@ -1,5 +1,13 @@
 .neo-modal--active {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 .neo-modal__content {

--- a/src/components/Modal/BasicModal/BasicModal_shim.css
+++ b/src/components/Modal/BasicModal/BasicModal_shim.css
@@ -1,3 +1,11 @@
 .neo-modal--active {
   justify-content: center;
 }
+
+.neo-modal__content {
+  animation: none;
+  position: absolute;
+  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}

--- a/src/components/Modal/BasicModal/BasicModal_shim.css
+++ b/src/components/Modal/BasicModal/BasicModal_shim.css
@@ -9,11 +9,3 @@
   justify-content: center;
   align-items: center;
 }
-
-.neo-modal__content {
-  animation: none;
-  position: absolute;
-  top: 0;
-  top: 50%;
-  transform: translateY(-50%);
-}

--- a/src/components/Modal/InfoModal.tsx
+++ b/src/components/Modal/InfoModal.tsx
@@ -1,8 +1,12 @@
-import { ReactNode, useId } from "react";
+import clsx from "clsx";
+import { forwardRef, ReactNode, useId } from "react";
 import ReactDOM from "react-dom";
+
+import "./BasicModal/BasicModal_shim.css";
 
 export interface InfoModalProps {
   children?: ReactNode;
+  className?: string;
   id?: string;
   onClose: React.ReactEventHandler<HTMLButtonElement>;
   open: boolean;
@@ -23,47 +27,59 @@ export interface InfoModalProps {
 
  * @see https://design.avayacloud.com/components/web/modal-web
  */
-export const InfoModal = ({
-  children,
-  id = useId(),
-  onClose,
-  open = false,
-  title,
-}: InfoModalProps) => {
-  if (!onClose) {
-    console.error("onClose prop is required.");
-  }
+export const InfoModal = forwardRef(
+  (
+    {
+      children,
+      className,
+      id = useId(),
+      onClose,
+      open = false,
+      title,
+    }: InfoModalProps,
+    ref: React.Ref<HTMLDivElement>
+  ) => {
+    if (!onClose) {
+      console.error("onClose prop is required.");
+    }
 
-  if (!open) {
-    return null;
-  }
+    if (!open) {
+      return null;
+    }
 
-  return ReactDOM.createPortal(
-    <div id={id} data-testid={id} className="neo-modal--active">
-      <div className="neo-modal__background"></div>
+    return ReactDOM.createPortal(
       <div
-        className="neo-modal__content"
-        aria-label="This is an informational modal" // TODO: What should this value be? Ask Matt or Terri.
-        aria-modal="true"
-        role="dialog"
+        id={id}
+        data-testid={id}
+        className={clsx("neo-modal--active", className)}
+        ref={ref}
       >
-        <div className="neo-modal__info-close">
-          <button
-            aria-label="close" // TODO: Localize this field.
-            className="neo-close"
-            onClick={onClose}
-          />
-        </div>
-        {title && (
-          <div className="neo-modal__header">
-            <h4>{title}</h4>
+        <div className="neo-modal__background"></div>
+        <div
+          className="neo-modal__content"
+          aria-label="This is an informational modal" // TODO: What should this value be? Ask Matt or Terri.
+          aria-modal="true"
+          role="dialog"
+        >
+          <div className="neo-modal__info-close">
+            <button
+              aria-label="close" // TODO: Localize this field.
+              className="neo-close"
+              onClick={onClose}
+            />
           </div>
-        )}
-        <div className="neo-modal__body">
-          <div className="neo-modal__message">{children}</div>
+          {title && (
+            <div className="neo-modal__header">
+              <h4>{title}</h4>
+            </div>
+          )}
+          <div className="neo-modal__body">
+            <div className="neo-modal__message">{children}</div>
+          </div>
         </div>
-      </div>
-    </div>,
-    document.body
-  );
-};
+      </div>,
+      document.body
+    );
+  }
+);
+InfoModal.displayName = "InfoModal";


### PR DESCRIPTION

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work

When displaying an InfoModal component, it will automatically center itself both horizontally and vertically in the main body of the page.
I also added the ability to pass a className and ref props to it.

![2022-08-25 09 48 24](https://user-images.githubusercontent.com/3535271/186724119-40524d55-1783-4429-8abe-ec8e607bf2a4.gif)


**IMPORTANT NOTES:**
- As a side effect, this PR will also center the BasicModal but further work will be needed to add the other props to it.
