### PR TITLE
NEO-1073: Adding showRowSeparator prop / feature to Table component

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -349,6 +349,10 @@ export const BareBones = () => (
   <Table columns={FilledFields.columns} data={[...FilledFields.data]} />
 );
 
+export const WithRowSeparator = () => (
+  <Table showRowSeparator columns={FilledFields.columns} data={[...FilledFields.data]} />
+);
+
 // BUG: initial values work, but they are unchangable
 export const PreSelectedRows = () => {
   const defaultSelectedRowIds = [

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -78,6 +78,7 @@ export const Table = <T extends Record<string, any>>({
   readonly = false,
   selectableRows = "none",
   rowHeight = "large",
+  showRowSeparator = false,
   translations,
 
   ...rest
@@ -187,7 +188,8 @@ export const Table = <T extends Record<string, any>>({
           className={clsx(
             "neo-table",
             rowHeight === "compact" && "neo-table--compact",
-            rowHeight === "medium" && "neo-table--medium"
+            rowHeight === "medium" && "neo-table--medium",
+            showRowSeparator && "neo-table-separator"
           )}
           aria-labelledby={tableCaptionId}
           aria-describedby={tableSummaryId}

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -22,5 +22,5 @@
 }
 
 .neo-table-separator td {
-      border-bottom: 1px solid #F1F1F1;
+  border-bottom: 1px solid #f1f1f1;
 }

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -20,3 +20,7 @@
 .neo-table th button.neo-dropdown__link-header::after {
   padding: 0 12px 0 0;
 }
+
+.neo-table-separator td {
+      border-bottom: 1px solid #F1F1F1;
+}

--- a/src/components/Table/types/TableTypes.ts
+++ b/src/components/Table/types/TableTypes.ts
@@ -51,6 +51,7 @@ export type TableProps<T extends Record<string, any>> = {
   itemsPerPageOptions?: number[];
   defaultSelectedRowIds?: string[];
   rowHeight?: "compact" | "medium" | "large";
+  showRowSeparator?: boolean;
   summary?: string;
   containerClassName?: string;
   translations?: ITableTranslations;


### PR DESCRIPTION

**Before tagging the team for a review, I have done the following:**
- [ x] reviewed my code changes
- [ x] ensured that all tests pass
- [ x] added any important information to this PR (description, images, GIFs, ect.)
- [x ] tagged Matt if any visual changes have occurred
- [ x] done an accessibility check on my work

When showRowSeparator is true, the tables will render with a separator line as indicated by the IAM Figma design. See story for details.

![image](https://user-images.githubusercontent.com/3535271/187555618-1079101e-4ff5-48cc-8804-0cb5bba7a327.png)

