### PR TITLE
NEO-1140: RadioGroup & Radio rework

### DIFF
--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -13,7 +13,7 @@ export const Radio: React.FC<RadioProps> = ({
   id = useId(),
   ...rest
 }: RadioProps) => {
-  const { value } = rest;
+  const { value, "aria-label": ariaLabel } = rest;
 
   const idForLabel = useMemo(() => `Radio-label-${value}`, [value]);
 
@@ -25,7 +25,7 @@ export const Radio: React.FC<RadioProps> = ({
         type="radio"
         id={id}
         aria-labelledby={idForLabel}
-        aria-label={value?.toString()}
+        aria-label={ariaLabel ? ariaLabel : value?.toString()}
       />
       <label id={idForLabel} htmlFor={id}>
         {children}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -8,11 +8,9 @@ export interface RadioProps
 export const Radio: React.FC<RadioProps> = ({
   children,
   id = useId(),
-  checked,
-  value,
   ...rest
 }: RadioProps) => {
-  const idForLabel = useMemo(() => `Radio-label-${value}`, [value]);
+  const idForLabel = useMemo(() => `Radio-label-${rest.value}`, [rest.value]);
 
   return (
     <>
@@ -21,10 +19,8 @@ export const Radio: React.FC<RadioProps> = ({
         className="neo-radio"
         type="radio"
         id={id}
-        checked={checked}
-        value={value}
         aria-labelledby={idForLabel}
-        aria-label={value?.toString()}
+        aria-label={rest.value?.toString()}
       />
       <label id={idForLabel} htmlFor={id}>
         {children}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -3,7 +3,7 @@ import { useMemo, useId } from "react";
 export interface RadioProps
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    "id" | "type" | "checked"
+    "id" | "type" | "checked" | "defaultChecked"
   > {
   id?: string;
 }

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -10,7 +10,9 @@ export const Radio: React.FC<RadioProps> = ({
   id = useId(),
   ...rest
 }: RadioProps) => {
-  const idForLabel = useMemo(() => `Radio-label-${rest.value}`, [rest.value]);
+  const { value } = rest;
+
+  const idForLabel = useMemo(() => `Radio-label-${value}`, [value]);
 
   return (
     <>
@@ -20,7 +22,7 @@ export const Radio: React.FC<RadioProps> = ({
         type="radio"
         id={id}
         aria-labelledby={idForLabel}
-        aria-label={rest.value?.toString()}
+        aria-label={value?.toString()}
       />
       <label id={idForLabel} htmlFor={id}>
         {children}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,52 +1,38 @@
-import { useMemo } from "react";
-
-import { Tooltip } from "components/Tooltip";
+import { useMemo, useId } from "react";
 
 export interface RadioProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "id" | "type"> {
   selected?: string; // TODO: and use `checked` (having `RadioGroup` set it)
-  tooltip?: string; // TODO: remove and add tooltip in story and test
-  label: string;
+  id?: string;
 }
 
-export const Radio = ({
+export const Radio: React.FC<RadioProps> = ({
+  children,
   selected,
-  tooltip,
-  label,
+  id = useId(),
   checked,
   value,
   ...rest
 }: RadioProps) => {
-  const idForLabel = useMemo(() => `radio-id-${value}`, [value]);
-  const radioTestId = useMemo(() => `Radio-root-${value}`, [value]);
-  const labelTestId = useMemo(() => `Radio-label-root-${value}`, [value]);
-
-  const Label = () => {
-    return (
-      <label htmlFor={idForLabel} data-testid={labelTestId}>
-        {label}
-      </label>
-    );
-  };
+  const idForLabel = useMemo(() => `Radio-label-${value}`, [value]);
 
   return (
     <>
       <input
         {...rest}
-        data-testid={radioTestId}
         className="neo-radio"
         type="radio"
-        id={idForLabel}
+        id={id}
         checked={checked || selected === value}
         value={value}
+        aria-labelledby={idForLabel}
+        aria-label={value?.toString()}
       />
-      {tooltip ? (
-        <Tooltip label={tooltip}>
-          <Label />
-        </Tooltip>
-      ) : (
-        <Label />
-      )}
+      <label id={idForLabel} htmlFor={id}>
+        {children}
+      </label>
     </>
   );
 };
+
+Radio.displayName = "Radio";

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -2,13 +2,11 @@ import { useMemo, useId } from "react";
 
 export interface RadioProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "id" | "type"> {
-  selected?: string; // TODO: and use `checked` (having `RadioGroup` set it)
   id?: string;
 }
 
 export const Radio: React.FC<RadioProps> = ({
   children,
-  selected,
   id = useId(),
   checked,
   value,
@@ -23,7 +21,7 @@ export const Radio: React.FC<RadioProps> = ({
         className="neo-radio"
         type="radio"
         id={id}
-        checked={checked || selected === value}
+        checked={checked}
         value={value}
         aria-labelledby={idForLabel}
         aria-label={value?.toString()}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useId } from "react";
 
 export interface RadioProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "id" | "type"> {
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "id" | "type" | "checked"
+  > {
   id?: string;
 }
 

--- a/src/components/Radio/RadioGroup.stories.tsx
+++ b/src/components/Radio/RadioGroup.stories.tsx
@@ -1,46 +1,68 @@
-import { Story } from "@storybook/react";
-
-import { RadioGroup, RadioGroupProps } from "./RadioGroup";
+import { RadioGroup } from "./RadioGroup";
+import { Radio } from "./Radio";
+import { Tooltip } from "components/Tooltip";
+import React, { useState } from "react";
 
 export default {
   title: "Components/Radio Group",
   component: RadioGroup,
 };
 
-const DefaultRadioArray = [
-  {
-    label: "Radio 1",
-    value: "Radio 1",
-  },
-  {
-    label: "Radio 2",
-    value: "Radio 2",
-  },
-  {
-    label: "Radio 3",
-    value: "Radio 3",
-  },
-  {
-    label: "Radio 4",
-    value: "Radio 4",
-    disabled: true,
-  },
-  {
-    label: "Radio 5",
-    value: "Radio 5",
-    disabled: true,
-    tooltip: "Tooltip for Radio",
-    position: "down",
-  },
-];
+export const RadioGroupExample = () => {
+  const [selectedValue, setSelectedValue] = useState("Radio 1");
 
-const Template: Story<RadioGroupProps> = (args: RadioGroupProps) => (
-  <RadioGroup {...args} />
-);
+  function onRadioChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setSelectedValue(event.target.value);
+  }
 
-export const Default = Template.bind({});
-Default.args = {
-  radios: DefaultRadioArray,
-  groupName: "Default Radio Group",
-  checked: "Radio 1",
+  return (
+    <>
+      <RadioGroup
+        groupName="Default Radio Group"
+        checked="Radio 1"
+        onChange={onRadioChange}
+      >
+        <Radio value="Radio 1">Radio 1</Radio>
+        <Radio value="Radio 2" disabled>
+          Radio 2
+        </Radio>
+        <Radio value="Radio 3">Radio 3</Radio>
+        <Tooltip label="Radio 4" position="right">
+          <Radio value="Radio 4">Radio 4</Radio>
+        </Tooltip>
+      </RadioGroup>
+      <br />
+      <p>Selected button is {selectedValue}</p>
+    </>
+  );
+};
+
+export const InlineRadioGroupExample = () => {
+  const [selectedValue, setSelectedValue] = useState("Radio 1");
+
+  function onRadioChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setSelectedValue(event.target.value);
+  }
+
+  return (
+    <>
+      <RadioGroup
+        groupName="Default Radio Group"
+        checked="Radio 1"
+        onChange={onRadioChange}
+        inline
+      >
+        <Radio value="Radio 1">Radio 1</Radio>
+        <Radio value="Radio 2" disabled>
+          Radio 2
+        </Radio>
+        <Radio value="Radio 3">Radio 3</Radio>
+        <Tooltip label="Radio 4">
+          <Radio value="Radio 4">Radio 4</Radio>
+        </Tooltip>
+      </RadioGroup>
+      <br />
+      <p>Selected button is {selectedValue}</p>
+    </>
+  );
 };

--- a/src/components/Radio/RadioGroup.stories.tsx
+++ b/src/components/Radio/RadioGroup.stories.tsx
@@ -1,7 +1,7 @@
 import { RadioGroup } from "./RadioGroup";
 import { Radio } from "./Radio";
-import { Tooltip } from "components/Tooltip";
-import React, { useState } from "react";
+import { Tooltip, Button, Form } from "components";
+import React, { useEffect, useState } from "react";
 
 export default {
   title: "Components/Radio Group",
@@ -16,10 +16,16 @@ export const RadioGroupExample = () => {
   }
 
   return (
-    <>
+    <Form
+      id="radio-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert(`you successfully submitted: ${selectedValue}`);
+      }}
+    >
       <RadioGroup
         groupName="Default Radio Group"
-        checked="Radio 1"
+        selected="Radio 1"
         onChange={onRadioChange}
       >
         <Radio value="Radio 1">Radio 1</Radio>
@@ -33,7 +39,57 @@ export const RadioGroupExample = () => {
       </RadioGroup>
       <br />
       <p>Selected button is {selectedValue}</p>
-    </>
+      <br />
+      <Button type="submit">Submit</Button>
+    </Form>
+  );
+};
+
+export const MockAPIRadioGroupExample = () => {
+  const [isDisabled, setIsDisabled] = useState(true);
+  const [selectedValue, setSelectedValue] = useState<string>();
+
+  function onRadioChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setSelectedValue(event.target.value);
+  }
+
+  useEffect(() => {
+    setTimeout(() => {
+      setIsDisabled(false);
+      setSelectedValue("Radio 3");
+    }, 3000);
+  }, []);
+
+  return (
+    <Form
+      id="radio-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert(`you successfully submitted: ${selectedValue}`);
+      }}
+    >
+      <RadioGroup
+        groupName="Default Radio Group"
+        selected={selectedValue}
+        onChange={onRadioChange}
+        disabled={isDisabled}
+      >
+        <Radio value="Radio 1">Radio 1</Radio>
+        <Radio value="Radio 2">Radio 2</Radio>
+        <Radio value="Radio 3">Radio 3</Radio>
+        <Tooltip label="Radio 4" position="right">
+          <Radio value="Radio 4">Radio 4</Radio>
+        </Tooltip>
+      </RadioGroup>
+      <br />
+      <p>
+        {selectedValue
+          ? `selected button is ${selectedValue}`
+          : "Loading selected value, please wait..."}
+      </p>
+      <br />
+      <Button type="submit">Submit</Button>
+    </Form>
   );
 };
 
@@ -48,7 +104,7 @@ export const InlineRadioGroupExample = () => {
     <>
       <RadioGroup
         groupName="Default Radio Group"
-        checked="Radio 1"
+        selected="Radio 1"
         onChange={onRadioChange}
         inline
       >

--- a/src/components/Radio/RadioGroup.stories.tsx
+++ b/src/components/Radio/RadioGroup.stories.tsx
@@ -25,7 +25,7 @@ export const RadioGroupExample = () => {
     >
       <RadioGroup
         groupName="Default Radio Group"
-        selected="Radio 1"
+        selected={selectedValue}
         onChange={onRadioChange}
       >
         <Radio value="Radio 1">Radio 1</Radio>
@@ -104,7 +104,7 @@ export const InlineRadioGroupExample = () => {
     <>
       <RadioGroup
         groupName="Default Radio Group"
-        selected="Radio 1"
+        selected={selectedValue}
         onChange={onRadioChange}
         inline
       >

--- a/src/components/Radio/RadioGroup.test.jsx
+++ b/src/components/Radio/RadioGroup.test.jsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, cleanup, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { composeStories } from "@storybook/testing-react";
 import * as RadioGroupStories from "./RadioGroup.stories";
@@ -9,49 +9,42 @@ import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom";
 
-async function axeTest(renderResult) {
-  const { container } = renderResult;
-  const results = await axe(container);
-  expect(results).toHaveNoViolations();
-}
-
 const { RadioGroupExample, InlineRadioGroupExample } =
   composeStories(RadioGroupStories);
 
 describe("RadioGroup", () => {
-  let renderResult;
-
   beforeEach(() => {
-    renderResult = render(
+    render(
       <RadioGroup groupName={"radioGroup"}>
         <Radio value="Radio 1">Radio 1</Radio>
       </RadioGroup>
     );
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it("radio group renders ok", () => {
-    const { getByRole } = renderResult;
-    const rootElement = getByRole("radiogroup");
+    const rootElement = screen.getByRole("radiogroup");
     expect(rootElement).toBeTruthy();
   });
 
   it("radio renders ok & with correct class name", () => {
-    const { getByLabelText } = renderResult;
-    const radioElement = getByLabelText("Radio 1");
+    const radioElement = screen.getByLabelText("Radio 1");
     expect(radioElement).toBeTruthy().toHaveAttribute("class", "neo-radio");
   });
 
   it("has an id value that matches the 'for' attribute on label", () => {
-    const { getByLabelText, getByText } = renderResult;
-
-    const radio = getByLabelText(`Radio 1`);
+    const radio = screen.getByLabelText(`Radio 1`);
     const radioId = radio.getAttribute("id");
-    const radioLabel = getByText("Radio 1");
+    const radioLabel = screen.getByText("Radio 1");
     expect(radioLabel).toHaveAttribute("for", radioId);
   });
 
   it("passes basic axe compliance", async () => {
-    await axeTest(renderResult);
+    const results = await axe(screen.getByTestId("RadioGroup-root"));
+    expect(results).toHaveNoViolations();
   });
 });
 
@@ -59,34 +52,30 @@ describe("Storybook tests", () => {
   const user = userEvent.setup();
 
   describe("RadioGroupExample", () => {
-    let renderResult;
-
     beforeEach(() => {
-      renderResult = render(<RadioGroupExample />);
+      render(<RadioGroupExample />);
+    });
+
+    afterEach(() => {
+      cleanup();
     });
 
     it("should render ok", () => {
-      const { container } = renderResult;
-      expect(container).not.toBe(null);
+      expect(screen.container).not.toBe(null);
     });
 
     it("passes basic axe compliance", async () => {
-      const { container } = renderResult;
-      const results = await axe(container);
+      const results = await axe(screen.getByTestId("RadioGroup-root"));
       expect(results).toHaveNoViolations();
     });
 
     it("renders as disabled", () => {
-      const { getByLabelText } = renderResult;
-
-      const disabledRadioButton = getByLabelText(`Radio 2`);
+      const disabledRadioButton = screen.getByLabelText(`Radio 2`);
       expect(disabledRadioButton).toHaveAttribute("disabled");
     });
 
     it("renders with a Tooltip in the correct position", () => {
-      const { getByRole } = renderResult;
-
-      const radioGroup = getByRole("radiogroup");
+      const radioGroup = screen.getByRole("radiogroup");
 
       expect(radioGroup.lastChild).toHaveAttribute(
         "class",
@@ -95,11 +84,11 @@ describe("Storybook tests", () => {
     });
 
     it("passes and responds to onChange handler correctly", async () => {
-      const { getByText, getByLabelText } = renderResult;
+      const selectedButtonPrompt = screen.getByText(
+        "Selected button is Radio 1"
+      );
 
-      const selectedButtonPrompt = getByText("Selected button is Radio 1");
-
-      const unselectedRadio = getByLabelText("Radio 3");
+      const unselectedRadio = screen.getByLabelText("Radio 3");
 
       await user.click(unselectedRadio);
 
@@ -110,27 +99,25 @@ describe("Storybook tests", () => {
   });
 
   describe("InlineRadioGroupExample", () => {
-    let renderResult;
-
     beforeEach(() => {
-      renderResult = render(<InlineRadioGroupExample />);
+      render(<InlineRadioGroupExample />);
+    });
+
+    afterEach(() => {
+      cleanup();
     });
 
     it("should render ok", () => {
-      const { container } = renderResult;
-      expect(container).not.toBe(null);
+      expect(screen.container).not.toBe(null);
     });
 
     it("passes basic axe compliance", async () => {
-      const { container } = renderResult;
-      const results = await axe(container);
+      const results = await axe(screen.getByTestId("RadioGroup-root"));
       expect(results).toHaveNoViolations();
     });
 
     it("renders with the correct class name for inline styles", () => {
-      const { getByRole } = renderResult;
-
-      const radioGroup = getByRole("radiogroup");
+      const radioGroup = screen.getByRole("radiogroup");
 
       expect(radioGroup).toHaveAttribute("class", "neo-input-group--inline");
     });

--- a/src/components/Radio/RadioGroup.test.jsx
+++ b/src/components/Radio/RadioGroup.test.jsx
@@ -1,8 +1,11 @@
 import { render } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { vi } from "vitest";
+import { composeStories } from "@storybook/testing-react";
+import * as RadioGroupStories from "./RadioGroup.stories";
 
-import { RadioGroup } from ".";
+import { RadioGroup, Radio } from ".";
+
+import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom";
 
@@ -12,123 +15,124 @@ async function axeTest(renderResult) {
   expect(results).toHaveNoViolations();
 }
 
-const DefaultRadioArray = [
-  {
-    label: "Radio 1",
-    value: "Radio 1",
-  },
-  {
-    label: "Radio 2",
-    value: "Radio 2",
-  },
-  {
-    label: "Radio 3",
-    value: "Radio 3",
-  },
-  {
-    label: "Radio 4",
-    value: "Radio 4",
-    disabled: true,
-  },
-  {
-    label: "Radio 5",
-    value: "Radio 5",
-    disabled: true,
-    tooltip: "Tooltip for Radio",
-    position: "down",
-  },
-];
-
-const DefaultProps = {
-  radios: DefaultRadioArray,
-  groupName: "Radio Group",
-  checked: "Radio 1",
-};
+const { RadioGroupExample, InlineRadioGroupExample } =
+  composeStories(RadioGroupStories);
 
 describe("RadioGroup", () => {
   let renderResult;
 
   beforeEach(() => {
-    vi.spyOn(console, "warn").mockImplementation(() => null);
-
-    renderResult = render(<RadioGroup {...DefaultProps} />);
+    renderResult = render(
+      <RadioGroup groupName={"radioGroup"}>
+        <Radio value="Radio 1">Radio 1</Radio>
+      </RadioGroup>
+    );
   });
 
   it("radio group renders ok", () => {
-    const { getByTestId } = renderResult;
-    const rootElement = getByTestId("RadioGroup-root");
+    const { getByRole } = renderResult;
+    const rootElement = getByRole("radiogroup");
     expect(rootElement).toBeTruthy();
   });
 
-  it("radio renders ok", () => {
-    const { getByTestId } = renderResult;
-    const rootElement = getByTestId("Radio-root-Radio 1");
-    expect(rootElement).toBeTruthy();
-  });
-
-  it("radio renders with correct class name", () => {
-    const { getByTestId } = renderResult;
-    const rootElement = getByTestId("Radio-root-Radio 1");
-    expect(rootElement).toHaveAttribute("class", "neo-radio");
-  });
-
-  it("has a value that matches the label", () => {
-    const { getByTestId } = renderResult;
-    DefaultRadioArray.forEach((radioObject) => {
-      const radio = getByTestId(`Radio-root-${radioObject.label}`);
-      expect(radio).toHaveAttribute("value", radioObject.label);
-    });
-  });
-
-  it("has an id that matches the label", () => {
-    const { getByTestId } = renderResult;
-    DefaultRadioArray.forEach((radioObject) => {
-      const radio = getByTestId(`Radio-root-${radioObject.label}`);
-      expect(radio).toHaveAttribute("id", `radio-id-${radioObject.label}`);
-    });
-  });
-
-  it("has an id value that matches the for attribute on label", () => {
-    const { getByTestId } = renderResult;
-    DefaultRadioArray.forEach((radioObject) => {
-      const radio = getByTestId(`Radio-root-${radioObject.label}`);
-      const radioLabel = getByTestId(`Radio-label-root-${radioObject.label}`);
-      expect(radio).toHaveAttribute("id", `radio-id-${radioObject.label}`);
-      expect(radioLabel).toHaveAttribute(
-        "for",
-        `radio-id-${radioObject.label}`
-      );
-    });
-  });
-
-  it("renders as disabled", () => {
-    const { getByTestId } = renderResult;
-    DefaultRadioArray.forEach((radio) => {
-      if (radio.disabled) {
-        const radioButton = getByTestId(`Radio-root-${radio.label}`);
-        expect(radioButton).toHaveAttribute("disabled");
-      } else {
-        const radioButton = getByTestId(`Radio-root-${radio.label}`);
-        expect(radioButton).not.toHaveAttribute("disabled");
-      }
-    });
-  });
-
-  it("renders with a Tooltip in the correct position", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => null);
+  it("radio renders ok & with correct class name", () => {
     const { getByLabelText } = renderResult;
-    DefaultRadioArray.forEach((radio) => {
-      if (radio.tootip) {
-        const radioTooltip = getByLabelText(radio.tooltip);
-        expect(radioTooltip).toHaveAttribute(
-          "class",
-          `neo-tooltip--${radio.position}`
-        );
-      }
-    });
+    const radioElement = getByLabelText("Radio 1");
+    expect(radioElement).toBeTruthy().toHaveAttribute("class", "neo-radio");
+  });
+
+  it("has an id value that matches the 'for' attribute on label", () => {
+    const { getByLabelText, getByText } = renderResult;
+
+    const radio = getByLabelText(`Radio 1`);
+    const radioId = radio.getAttribute("id");
+    const radioLabel = getByText("Radio 1");
+    expect(radioLabel).toHaveAttribute("for", radioId);
   });
 
   it("passes basic axe compliance", async () => {
     await axeTest(renderResult);
+  });
+});
+
+describe("Storybook tests", () => {
+  const user = userEvent.setup();
+
+  describe("RadioGroupExample", () => {
+    let renderResult;
+
+    beforeEach(() => {
+      renderResult = render(<RadioGroupExample />);
+    });
+
+    it("should render ok", () => {
+      const { container } = renderResult;
+      expect(container).not.toBe(null);
+    });
+
+    it("passes basic axe compliance", async () => {
+      const { container } = renderResult;
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("renders as disabled", () => {
+      const { getByLabelText } = renderResult;
+
+      const disabledRadioButton = getByLabelText(`Radio 2`);
+      expect(disabledRadioButton).toHaveAttribute("disabled");
+    });
+
+    it("renders with a Tooltip in the correct position", () => {
+      const { getByRole } = renderResult;
+
+      const radioGroup = getByRole("radiogroup");
+
+      expect(radioGroup.lastChild).toHaveAttribute(
+        "class",
+        "neo-tooltip neo-tooltip--right neo-tooltip--onhover"
+      );
+    });
+
+    it("passes and responds to onChange handler correctly", async () => {
+      const { getByText, getByLabelText } = renderResult;
+
+      const selectedButtonPrompt = getByText("Selected button is Radio 1");
+
+      const unselectedRadio = getByLabelText("Radio 3");
+
+      await user.click(unselectedRadio);
+
+      expect(selectedButtonPrompt).toHaveTextContent(
+        "Selected button is Radio 3"
+      );
+    });
+  });
+
+  describe("InlineRadioGroupExample", () => {
+    let renderResult;
+
+    beforeEach(() => {
+      renderResult = render(<InlineRadioGroupExample />);
+    });
+
+    it("should render ok", () => {
+      const { container } = renderResult;
+      expect(container).not.toBe(null);
+    });
+
+    it("passes basic axe compliance", async () => {
+      const { container } = renderResult;
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("renders with the correct class name for inline styles", () => {
+      const { getByRole } = renderResult;
+
+      const radioGroup = getByRole("radiogroup");
+
+      expect(radioGroup).toHaveAttribute("class", "neo-input-group--inline");
+    });
   });
 });

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -1,13 +1,13 @@
 import {
   Children,
   cloneElement,
-  FC,
   ReactElement,
   useCallback,
   useEffect,
   useMemo,
   useState,
   useId,
+  FC,
 } from "react";
 
 import { NeoInputWrapper } from "components/NeoInputWrapper";
@@ -19,7 +19,8 @@ export interface RadioGroupProps {
   groupName: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   id?: string;
-  checked?: string;
+  disabled?: boolean;
+  selected?: string;
   label?: boolean;
   inline?: boolean;
   helperText?: string;
@@ -32,20 +33,21 @@ export const RadioGroup = ({
   groupName,
   onChange,
   id = useId(),
-  checked,
+  disabled,
+  selected,
   label,
   inline,
   helperText,
   error,
   required,
 }: RadioGroupProps) => {
-  const [selectedValue, setSelectedValue] = useState(checked);
+  const [selectedValue, setSelectedValue] = useState(selected);
 
   const helperTextId = `${id}-helper-text`;
 
   useEffect(() => {
-    setSelectedValue(checked);
-  }, [checked]);
+    setSelectedValue(selected);
+  }, [selected]);
 
   const onChangeHandler = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -66,6 +68,7 @@ export const RadioGroup = ({
           name: groupName,
           "aria-describedby": helperText ? helperText : "",
           onChange: onChangeHandler,
+          disabled,
         };
 
         // NOTE: The below seems kind of hacky, but I was unable to find a better way to make sure

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -64,7 +64,6 @@ export const RadioGroup = ({
 
         const propsToPass = {
           name: groupName,
-          selected: selectedValue,
           "aria-describedby": helperText ? helperText : "",
           onChange: onChangeHandler,
         };
@@ -78,6 +77,7 @@ export const RadioGroup = ({
           const childprops = {
             ...radio.props,
             ...propsToPass,
+            checked: radio.props.value === selectedValue,
           };
 
           const radioWithProps = cloneElement(radio, childprops);
@@ -87,6 +87,7 @@ export const RadioGroup = ({
           const childprops = {
             ...child.props,
             ...propsToPass,
+            checked: child.props.value === selectedValue,
           };
 
           return cloneElement(child, childprops);

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -71,9 +71,7 @@ export const RadioGroup = ({
         // NOTE: The below seems kind of hacky, but I was unable to find a better way to make sure
         // that the correct props are passed to child Radios even when wrapped in a Tooltip
 
-        console.log((child.type as FC).name);
-
-        if ((child.type as FC).name === "Tooltip") {
+        if ((child.type as FC).displayName === "Tooltip") {
           radio = child.props.children as ReactElement;
 
           const childprops = {

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -69,7 +69,7 @@ export const RadioGroup = ({
         };
 
         // NOTE: The below seems kind of hacky, but I was unable to find a better way to make sure
-        // that the correct props are passed to child Radios evem when wrapped in a Tooltip
+        // that the correct props are passed to child Radios even when wrapped in a Tooltip
 
         if ((child.type as FC).name === "Tooltip") {
           radio = child.props.children as ReactElement;

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -71,6 +71,8 @@ export const RadioGroup = ({
         // NOTE: The below seems kind of hacky, but I was unable to find a better way to make sure
         // that the correct props are passed to child Radios even when wrapped in a Tooltip
 
+        console.log((child.type as FC).name);
+
         if ((child.type as FC).name === "Tooltip") {
           radio = child.props.children as ReactElement;
 

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -10,7 +10,7 @@ import {
   FC,
 } from "react";
 
-import { NeoInputWrapper } from "components/NeoInputWrapper";
+import { NeoInputWrapper, Tooltip } from "components";
 
 import "./RadioGroup_shim.css";
 
@@ -74,7 +74,7 @@ export const RadioGroup = ({
         // NOTE: The below seems kind of hacky, but I was unable to find a better way to make sure
         // that the correct props are passed to child Radios even when wrapped in a Tooltip
 
-        if ((child.type as FC).displayName === "Tooltip") {
+        if (child.type === Tooltip) {
           radio = child.props.children as ReactElement;
 
           const childprops = {

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -3,11 +3,8 @@ import {
   cloneElement,
   ReactElement,
   useCallback,
-  useEffect,
   useMemo,
-  useState,
   useId,
-  FC,
 } from "react";
 
 import { NeoInputWrapper, Tooltip } from "components";
@@ -41,22 +38,15 @@ export const RadioGroup = ({
   error,
   required,
 }: RadioGroupProps) => {
-  const [selectedValue, setSelectedValue] = useState(selected);
-
   const helperTextId = `${id}-helper-text`;
-
-  useEffect(() => {
-    setSelectedValue(selected);
-  }, [selected]);
 
   const onChangeHandler = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setSelectedValue(e.target.value);
       if (onChange) {
         onChange(e);
       }
     },
-    [onChange, setSelectedValue]
+    [onChange]
   );
 
   const radios = useMemo(
@@ -80,7 +70,7 @@ export const RadioGroup = ({
           const childprops = {
             ...radio.props,
             ...propsToPass,
-            checked: radio.props.value === selectedValue,
+            checked: radio.props.value === selected,
           };
 
           const radioWithProps = cloneElement(radio, childprops);
@@ -90,13 +80,13 @@ export const RadioGroup = ({
           const childprops = {
             ...child.props,
             ...propsToPass,
-            checked: child.props.value === selectedValue,
+            checked: child.props.value === selected,
           };
 
           return cloneElement(child, childprops);
         }
       }),
-    [children, selectedValue, groupName, helperText, onChangeHandler]
+    [children, selected, groupName, helperText, onChangeHandler]
   );
 
   return (

--- a/src/components/Radio/RadioGroup_shim.css
+++ b/src/components/Radio/RadioGroup_shim.css
@@ -1,0 +1,128 @@
+.neo-radio-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.neo-radio + .neo-tooltip > label:before {
+  border: 1px solid var(--radio-border);
+}
+
+.neo-radio:not(.neo-radio-readonly):checked + .neo-tooltip > label:after {
+  background-color: var(--radio-background-active-color);
+}
+
+.neo-input-group--inline .neo-radio + label + .neo-tooltip {
+  display: flex;
+  margin-top: 0px;
+}
+
+.neo-input-group--inline label:not(.neo-switch):not(.neo-label) {
+  line-height: initial;
+}
+
+.neo-radio + label + .neo-tooltip {
+  width: fit-content;
+  margin-top: 8px;
+}
+.neo-radio + label + .neo-tooltip label {
+  padding-left: 24px;
+  pointer-events: initial !important;
+  color: var(--global-font-color);
+  cursor: pointer;
+  text-indent: 24px;
+  margin-top: 8px;
+  position: relative;
+  font-size: 14px !important;
+}
+
+[dir="rtl"] .neo-radio + label + .neo-tooltip label {
+  margin-right: 0;
+}
+
+.neo-radio + label + .neo-tooltip label:after {
+  background-color: var(--radio-background);
+  content: "";
+  height: 10px;
+  width: 10px;
+  background-color: var(--radio-background);
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 5px;
+  left: 3px;
+}
+
+[dir="rtl"] .neo-radio + label + .neo-tooltip label:after {
+  left: auto;
+  right: 3px;
+}
+
+.neo-radio + label + .neo-tooltip label:before {
+  background-color: var(--radio-background);
+  content: "";
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 2px;
+}
+
+.neo-radio:checked + label + .neo-tooltip label:after {
+  content: "";
+  height: 10px;
+  width: 10px;
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 5px;
+  left: 3px;
+}
+
+[dir="rtl"] .neo-radio:checked + label + .neo-tooltip label:after {
+  left: auto;
+  right: 3px;
+}
+
+.neo-radio.neo-radio--disabled + label + .neo-tooltip label {
+  cursor: not-allowed;
+  color: var(--global-disabled-color);
+}
+
+.neo-radio.neo-radio--disabled + label + .neo-tooltip label:before {
+  border: var(--radio-disabled-border);
+}
+
+.neo-radio.neo-radio--disabled:checked + label + .neo-tooltip label:after {
+  background-color: var(--radio-background);
+  content: "";
+  height: 10px;
+  width: 10px;
+  background-color: var(--radio-background);
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 5px;
+  left: 3px;
+}
+
+[dir="rtl"]
+  .neo-radio.neo-radio--disabled:checked
+  + label
+  + .neo-tooltip
+  label:after {
+  left: auto;
+  right: 3px;
+}
+
+.neo-radio.neo-radio--disabled:checked + label + .neo-tooltip label:before {
+  background-color: var(--radio-background);
+  border: var(--radio-disabled-border);
+  content: "";
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 2px;
+}

--- a/src/components/Radio/RadioGroup_shim.css
+++ b/src/components/Radio/RadioGroup_shim.css
@@ -79,6 +79,11 @@
   left: 3px;
 }
 
+.neo-tooltip .neo-radio[disabled] + label {
+  cursor: not-allowed;
+  color: #757474;
+}
+
 [dir="rtl"] .neo-radio:checked + label + .neo-tooltip label:after {
   left: auto;
   right: 3px;


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-32--neo-react-library-storybook.netlify.app/)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

Re-worked RadioGroup and Radio Components as per [NEO-1140](https://jira.forge.avaya.com/browse/NEO-1140) for improved logic, accessibility and usability, added tests for new functionality, created CSS shim file for necessary updates and to accommodate using Tooltip as a child component of RadioGroup.

The main challenge in this work was to ensure the correct props were passed from the `RadioGroup` to child `Radio` Components, even when wrapped in a Tooltip. I did find a way to do this, but any feedback towards better/more elegant solutions is of course welcome.

**EXAMPLE FUNCTIONALITY GIF:**
![RadioGroup gif](https://user-images.githubusercontent.com/61242168/190269526-66c835ed-cd86-4395-aaf8-dc7c1ba43e12.gif)
