### PR TITLE
remove `react-stopwatch` from peer deps as we _only_ use it for a story

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-roving-tabindex": "^3.2.0",
-    "react-stopwatch": "^2.0.4",
     "react-table": "^7.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`react-stopwatch` is _only_ used for a story, so I'm not sure why it was a peer dep in the first place, but now it's _only_ a dev dep, so it shouldn't cause the person any more issues after this is merged and published 