### PR TITLE
NEO-1214 open link when enter is pressed on a TabLink

### DIFF
--- a/src/components/Tab/EventHandlers/KeyboardEventHandlers.test.jsx
+++ b/src/components/Tab/EventHandlers/KeyboardEventHandlers.test.jsx
@@ -455,7 +455,7 @@ function getTabLinkProps() {
     {
       content: "content 2",
       disabled: false,
-      href: "somelinek",
+      href: "http://somelink.com",
       id: "tab2",
       name: "tab2",
     },

--- a/src/components/Tab/EventHandlers/KeyboardEventHandlers.test.jsx
+++ b/src/components/Tab/EventHandlers/KeyboardEventHandlers.test.jsx
@@ -9,7 +9,7 @@ import {
   handleFocusEvent,
   handleKeyDownEvent,
 } from "./KeyboardEventHandlers";
-import { activatePreviousTab, getNextTabIndex } from "./KeyboardHelper";
+import { activatePreviousTab, getNextTabIndex, isTabLink } from "./KeyboardHelper";
 
 vi.mock("./KeyboardHelper");
 vi.mock("./Helper");
@@ -182,10 +182,15 @@ describe("Tab Keyboard event handlers", () => {
           stopPropagation: vi.fn(),
           preventDefault: vi.fn(),
         };
+        vi.resetAllMocks();
       });
-      it("should do nothing if tab is vertical", () => {
+      it("should show panel after pressing enter on Tab", () => {
         testEnterOrSpaceKeyDown(e, setActiveTabIndex, setActivePanelIndex, ref);
       });
+      it("should open link after pressing enter on TabLink", () => {
+        isTabLink.mockReturnValue(true)
+        testLinkOpenOnEnterOrSpaceKeyDown(e, setActiveTabIndex, setActivePanelIndex, ref);
+      })
     });
     describe(Keys.SPACE, () => {
       let e;
@@ -195,10 +200,15 @@ describe("Tab Keyboard event handlers", () => {
           stopPropagation: vi.fn(),
           preventDefault: vi.fn(),
         };
+        vi.resetAllMocks();
       });
       it("should call setActivePanelIndex and focus", () => {
         testEnterOrSpaceKeyDown(e, setActiveTabIndex, setActivePanelIndex, ref);
       });
+      it("should open link after pressing enter on TabLink", () => {
+        isTabLink.mockReturnValue(true)
+        testLinkOpenOnEnterOrSpaceKeyDown(e, setActiveTabIndex, setActivePanelIndex, ref);
+      })
     });
     describe(Keys.RIGHT, () => {
       let e;
@@ -434,6 +444,30 @@ function getTabProps() {
   ];
 }
 
+function getTabLinkProps() {
+  return [
+    {
+      content: <h2>content1</h2>,
+      disabled: false,
+      id: "tab1",
+      name: "tab1",
+    },
+    {
+      content: "content 2",
+      disabled: false,
+      href: "somelinek",
+      id: "tab2",
+      name: "tab2",
+    },
+    {
+      content: "content 3",
+      disabled: false,
+      id: "tab3",
+      name: "tab3",
+    },
+  ];
+}
+
 function testCloseElementKeyDown(e, setActiveTabIndex, setActivePanelIndex) {
   expect(
     handleCloseElementKeyDownEvent(
@@ -468,4 +502,25 @@ function testEnterOrSpaceKeyDown(
   expect(setActivePanelIndex).toBeCalledWith(1);
   expect(e.stopPropagation).toHaveBeenCalled();
   expect(e.preventDefault).toHaveBeenCalled();
+}
+
+function testLinkOpenOnEnterOrSpaceKeyDown(
+  e,
+  setActiveTabIndex,
+  setActivePanelIndex,
+  ref
+) {
+  const tabs = getTabLinkProps();
+  handleKeyDownEvent(
+    e,
+    false,
+    tabs,
+    1,
+    setActiveTabIndex,
+    setActivePanelIndex,
+    ref
+  );
+  expect(e.preventDefault).not.toBeCalled();
+  expect(setActivePanelIndex).not.toBeCalled();
+  expect(e.stopPropagation).toHaveBeenCalled();
 }

--- a/src/components/Tab/EventHandlers/KeyboardEventHandlers.ts
+++ b/src/components/Tab/EventHandlers/KeyboardEventHandlers.ts
@@ -11,7 +11,11 @@ import { isAriaDisabled, Keys } from "utils";
 
 import { InternalTabProps } from "../InternalTabTypes";
 import { activateAnotherTabAndPanel } from "./Helper";
-import { activatePreviousTab, getNextTabIndex } from "./KeyboardHelper";
+import {
+  activatePreviousTab,
+  getNextTabIndex,
+  isTabLink,
+} from "./KeyboardHelper";
 
 const logger = log.getLogger("tab-keyboard-event-handler");
 logger.disableAll();
@@ -160,9 +164,11 @@ export const handleKeyDownEvent = (
       break;
     case Keys.ENTER:
     case Keys.SPACE:
-      e.preventDefault();
-      setActivePanelIndex(activeTabIndex);
-      focus(ref, tabs[activeTabIndex].id);
+      if (!isTabLink(tabs, activeTabIndex)) {
+        e.preventDefault();
+        setActivePanelIndex(activeTabIndex);
+        focus(ref, tabs[activeTabIndex].id);
+      }
       break;
   }
   e.stopPropagation();

--- a/src/components/Tab/EventHandlers/KeyboardHelper.test.jsx
+++ b/src/components/Tab/EventHandlers/KeyboardHelper.test.jsx
@@ -4,6 +4,7 @@ import {
   activatePreviousTab,
   getNextTabIndex,
   getPreviousTabIndex,
+  isTabLink
 } from "./KeyboardHelper";
 
 describe("Tab -> EventHandlers -> Helper", () => {
@@ -80,6 +81,19 @@ describe("Tab -> EventHandlers -> Helper", () => {
       const tabs = [{}, { disabled: true }, {}];
       const activeTabIndex = 0;
       expect(getPreviousTabIndex(tabs, activeTabIndex)).toBe(activeTabIndex);
+    });
+  });
+
+  describe("isTabLink", () => {
+    it("when href is defined, return true", () => {
+      const tabs = [{}, { href: "http://faq.com" }, {}];
+      const activeTabIndex = 1;
+      expect(isTabLink(tabs, activeTabIndex)).toBe(true);
+    });
+    it("when href is not defined, return false", () => {
+      const tabs = [{}, {}, {}];
+      const activeTabIndex = 1;
+      expect(isTabLink(tabs, activeTabIndex)).toBe(false);
     });
   });
 });

--- a/src/components/Tab/EventHandlers/KeyboardHelper.ts
+++ b/src/components/Tab/EventHandlers/KeyboardHelper.ts
@@ -54,3 +54,11 @@ export function activatePreviousTab(
     return false;
   }
 }
+
+export const isTabLink = (
+  tabs: InternalTabProps[],
+  activeTabIndex: number
+): boolean => {
+  const tab = tabs[activeTabIndex];
+  return !!tab.href;
+};


### PR DESCRIPTION
[To test, move to the last tab using arrow keys, then press enter](https://deploy-preview-53--neo-react-library-storybook.netlify.app/?path=/story/components-tab--uncontrolled-active-tab-story)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

Press "enter" on a TabLink should open link in another browser tab.
