### PR TITLE
NEO-1253 // resolve Checkbox Group a11y issue

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -16,7 +16,7 @@ export default {
 
 export const Default = () => {
   return (
-    <CheckboxGroup groupName="Single checkbox">
+    <CheckboxGroup groupName="single-checkbox" label="Single Checkbox">
       <Checkbox value="1">example label</Checkbox>
     </CheckboxGroup>
   );


### PR DESCRIPTION
[Link to updated Checkbox Group](https://deploy-preview-75--neo-react-library-storybook.netlify.app/?path=/story/components-checkbox-group--default)

**Before tagging the team for a review, I have done the following:**
- [ ] reviewed my code changes
- [ ] ensured that all tests pass
- [ ] updated the link at the top of this PR (or remove it if not applicable)
- [ ] added any important information to this PR (description, images, GIFs, ect.)
- [ ] tagged Matt if any visual changes have occurred
- [ ] done an accessibility check on my work

Yang realized that we had a a11y issue in that the Checkbox Group component was not appropriately associated with the Checkboxes. I did some research and discovered that although the general recommendation is to use `<fieldset>` and `<legend>` [with a group of checkboxes](https://github.com/avaya-dux/neo-react-library/pull/75), because we need to allow the user to pass their own label (as in the DPv3), [the alternative recommendation is to use `role="group"` with `aria-labelledby`](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria). [More on the "group role" here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role).