### PR TITLE
Bump version to 0.7.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaya/neo-react",
-  "version": "0.7.11",
+  "version": "0.7.13",
   "description": "This is the React version of the shared library called 'NEO' buit by Avaya",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "github:avaya-dux/neo-react-library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaya/neo-react",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "This is the React version of the shared library called 'NEO' buit by Avaya",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "github:avaya-dux/neo-react-library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaya/neo-react",
-  "version": "0.7.12",
+  "version": "0.7.11",
   "description": "This is the React version of the shared library called 'NEO' buit by Avaya",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "github:avaya-dux/neo-react-library",

--- a/readmes/how-to-publish.md
+++ b/readmes/how-to-publish.md
@@ -5,7 +5,9 @@ from the root of the directory
 - `npm login`: to ensure that you are properly logged in to the NPM network
 - `yarn all`: this will clean out all build artifacts, rebuild everything, run all tests, and "pack" the tarball if everything was successful
 - `yarn publish`: publishes the generated tarball to our registry
+- - note: At "new version" prompt, type in current version.
 - - note: to skip the "version" prompt, you can use: `yarn publish --new-version <version to publish>`
+
 
 
 You can check that the package was properly published by viewing it on NPMJS
@@ -26,3 +28,4 @@ Once that is complete, the next step is to add the release to our GitHub
 - click: "Auto-generate release notes"
 - attach the binary generated from `yarn all` (tgz file)
 - click: "Publish release"
+- create a PR and bump package.json version

--- a/readmes/how-to-publish.md
+++ b/readmes/how-to-publish.md
@@ -9,7 +9,6 @@ from the root of the directory
 - - note: to skip the "version" prompt, you can use: `yarn publish --new-version <version to publish>`
 
 
-
 You can check that the package was properly published by viewing it on NPMJS
 - [link to registry](https://registry.npmjs.org/@avaya%2fneo-react): api call, returns JSON, no cache
 - [link to npmjs page](https://www.npmjs.com/package/@avaya/neo-react): our page on NPMJS, is on a 60min cache


### PR DESCRIPTION
Note: 0.7.12 was used accidentally, can not be used again. 
