### PR TITLE
NEO-1302: aria-label no longer hardcoded.

### DIFF
--- a/src/components/Modal/InfoModal.tsx
+++ b/src/components/Modal/InfoModal.tsx
@@ -34,6 +34,7 @@ export const InfoModal = forwardRef(
   ) => {
     const generatedId = useId();
     id = id || generatedId;
+    const titleId = id + '-title';
     if (!onClose) {
       console.error("onClose prop is required.");
     }
@@ -52,7 +53,7 @@ export const InfoModal = forwardRef(
         <div className="neo-modal__background"></div>
         <div
           className="neo-modal__content"
-          aria-label="This is an informational modal" // TODO: What should this value be? Ask Matt or Terri.
+          aria-labelledby={titleId}
           aria-modal="true"
           role="dialog"
         >
@@ -65,7 +66,7 @@ export const InfoModal = forwardRef(
           </div>
           {title && (
             <div className="neo-modal__header">
-              <h4>{title}</h4>
+              <h4 id={titleId}>{title}</h4>
             </div>
           )}
           <div className="neo-modal__body">


### PR DESCRIPTION
https://deploy-preview-99--neo-react-library-storybook.netlify.app/?path=/story/components-modal-info-modal--portal-info-modal-example

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work

aria-label now defaults to whatever it is passed in as title prop.
