### PR TITLE
NEO-1388 style changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "loglevel": "^1.8.0",
     "react-click-away-listener": "^2.2.2",
     "react-focus-lock": "^2.9.1",
+    "react-input-autosize": "^3.0.0",
     "styled-components": "^5.3.6"
   },
   "peerDependencies": {
@@ -87,6 +88,7 @@
     "@types/jest-axe": "^3.5.5",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
+    "@types/react-input-autosize": "^2.2.1",
     "@types/react-table": "^7.7.12",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -55,12 +55,12 @@ export const MultiSelect = () => {
       )}
     >
       <span className="neo-multiselect-combo__header">
-        <span className="neo-padded-container">
+        <span className="neo-multiselect__padded-container">
           {selectedItemsAsChips}
 
           <button
             {...getToggleButtonProps()}
-            className="neo-multiselect__header neo-multiselect__header--no-after neo-button--width-10px"
+            className="neo-multiselect__header neo-multiselect__header--no-after"
             type="button"
             aria-label={ariaLabel}
           >

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -55,21 +55,26 @@ export const MultiSelect = () => {
       )}
     >
       <span className="neo-multiselect-combo__header">
-        {selectedItemsAsChips}
+        <span className="neo-padded-container">
+          {selectedItemsAsChips}
 
-        <button
-          {...getToggleButtonProps()}
-          className="neo-multiselect__header neo-multiselect__header--no-after"
-          type="button"
-          aria-label={ariaLabel}
-        >
-          {selectedItemsAsChips ? <>&nbsp;</> : placeholder}
-        </button>
+          <button
+            {...getToggleButtonProps()}
+            className="neo-multiselect__header neo-multiselect__header--no-after neo-button--width-10px"
+            type="button"
+            aria-label={ariaLabel}
+          >
+            {selectedItemsAsChips ? <>&nbsp;</> : placeholder}
+          </button>
+        </span>
       </span>
 
       <div
         aria-label={ariaLabel}
-        className="neo-multiselect__content"
+        className={clsx(
+          "neo-multiselect__content",
+          isOpen && "neo-set-keyboard-focus"
+        )}
         {...getMenuProps()}
       >
         <OptionsWithEmptyMessageFallback />

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -103,7 +103,7 @@ export const MultiSelectSearchable = () => {
               onKeyDown(e);
             }}
             onChange={(e) => {
-              logger.debug({onChangeCalled: e.target.value});
+              logger.debug({ onChangeCalled: e.target.value });
               setInputValue(e.target.value);
             }}
           />

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -80,13 +80,13 @@ export const MultiSelectSearchable = () => {
         {...getToggleButtonProps()}
         className="neo-multiselect-combo__header"
       >
-        <span className="neo-padded-container">
+        <span className="neo-multiselect__padded-container">
           {selectedItemsAsChips}
           <AutosizeInput
             {...restInputProps}
             value={inputValue}
             style={{ border: 0, height: "26px", display: "inline-block" }}
-            inputClassName="neo-input neo-input--height-26px"
+            inputClassName="neo-input"
             disabled={disabled}
             placeholder={placeholder}
             onKeyDown={(e) => {

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { UseComboboxReturnValue } from "downshift";
 import { useContext, useEffect, useMemo } from "react";
+import AutosizeInput from "react-input-autosize";
 
 import { Chip } from "components/Chip";
 import { Keys } from "utils";
@@ -75,28 +76,30 @@ export const MultiSelectSearchable = () => {
         {...getToggleButtonProps()}
         className="neo-multiselect-combo__header"
       >
-        {selectedItemsAsChips}
+        <span className="neo-padded-container">
+          {selectedItemsAsChips}
+          <AutosizeInput
+            {...restInputProps}
+            value={inputValue}
+            style={{ border: 0, height: "26px", display: "inline-block" }}
+            inputClassName="neo-input neo-input__height-26px"
+            disabled={disabled}
+            placeholder={placeholder}
+            onKeyDown={(e) => {
+              if (
+                e.key === Keys.ENTER &&
+                filteredOptions.length === 1 &&
+                !filteredOptions[0].disabled
+              ) {
+                toggleItem(filteredOptions[0]);
+              } else if (e.key === Keys.BACKSPACE && inputValue.length === 0) {
+                toggleItem(selectedItems[selectedItems.length - 1]);
+              }
 
-        <input
-          {...restInputProps}
-          className="neo-input"
-          disabled={disabled}
-          placeholder={placeholder}
-          onKeyDown={(e) => {
-            if (
-              e.key === Keys.ENTER &&
-              filteredOptions.length === 1 &&
-              !filteredOptions[0].disabled
-            ) {
-              toggleItem(filteredOptions[0]);
-            } else if (e.key === Keys.BACKSPACE && inputValue.length === 0) {
-              toggleItem(selectedItems[selectedItems.length - 1]);
-            }
-
-            onKeyDown(e);
-          }}
-        />
-
+              onKeyDown(e);
+            }}
+          />
+        </span>
         <input
           className="neo-display-none"
           id={id}
@@ -108,7 +111,10 @@ export const MultiSelectSearchable = () => {
 
       <div
         aria-label={ariaLabel}
-        className="neo-multiselect__content"
+        className={clsx(
+          "neo-multiselect__content",
+          isOpen && "neo-set-keyboard-focus"
+        )}
         {...getMenuProps()}
       >
         <OptionsWithEmptyMessageFallback />

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -82,7 +82,7 @@ export const MultiSelectSearchable = () => {
             {...restInputProps}
             value={inputValue}
             style={{ border: 0, height: "26px", display: "inline-block" }}
-            inputClassName="neo-input neo-input__height-26px"
+            inputClassName="neo-input neo-input--height-26px"
             disabled={disabled}
             placeholder={placeholder}
             onKeyDown={(e) => {

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -1,3 +1,5 @@
+import log from "loglevel";
+
 import clsx from "clsx";
 import { UseComboboxReturnValue } from "downshift";
 import { useContext, useEffect, useMemo } from "react";
@@ -10,6 +12,8 @@ import { SelectContext } from "../utils/SelectContext";
 import { SelectOptionProps } from "../utils/SelectTypes";
 import { OptionsWithEmptyMessageFallback } from "./OptionsWithEmptyMessageFallback";
 
+const logger = log.getLogger("multiple-select-searchable");
+logger.disableAll();
 export const MultiSelectSearchable = () => {
   const {
     downshiftProps,
@@ -95,8 +99,12 @@ export const MultiSelectSearchable = () => {
               } else if (e.key === Keys.BACKSPACE && inputValue.length === 0) {
                 toggleItem(selectedItems[selectedItems.length - 1]);
               }
-
+              logger.debug(e);
               onKeyDown(e);
+            }}
+            onChange={(e) => {
+              logger.debug({onChangeCalled: e.target.value});
+              setInputValue(e.target.value);
             }}
           />
         </span>

--- a/src/components/Select/InternalComponents/SingleSelect.tsx
+++ b/src/components/Select/InternalComponents/SingleSelect.tsx
@@ -42,7 +42,10 @@ export const SingleSelect = () => {
       </span>
 
       <div
-        className="neo-multiselect__content"
+        className={clsx(
+          "neo-multiselect__content",
+          isOpen && "neo-set-keyboard-focus"
+        )}
         aria-label={ariaLabel}
         {...getMenuProps()}
       >

--- a/src/components/Select/InternalComponents/SingleSelect.tsx
+++ b/src/components/Select/InternalComponents/SingleSelect.tsx
@@ -33,7 +33,7 @@ export const SingleSelect = () => {
       <span className="neo-multiselect-combo__header">
         <button
           {...getToggleButtonProps()}
-          className="neo-multiselect__header"
+          className="neo-multiselect__header neo-multiselect__header--no-after"
           type="button"
           aria-label={ariaLabel}
         >

--- a/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
@@ -68,7 +68,7 @@ export const SingleSelectSearchable = () => {
         {...getToggleButtonProps()}
         className="neo-multiselect-combo__header"
       >
-        <span className="neo-padded-container">
+        <span className="neo-multiselect__padded-container">
           {selectedItems[0] && (
             <Chip
               closable
@@ -84,7 +84,7 @@ export const SingleSelectSearchable = () => {
 
           <input
             {...restInputProps}
-            className="neo-input neo-input--height-26px"
+            className="neo-input"
             disabled={disabled}
             placeholder={placeholder}
             onKeyDown={(e) => {

--- a/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
@@ -84,7 +84,7 @@ export const SingleSelectSearchable = () => {
 
           <input
             {...restInputProps}
-            className="neo-input neo-input__height-26px"
+            className="neo-input neo-input--height-26px"
             disabled={disabled}
             placeholder={placeholder}
             onKeyDown={(e) => {

--- a/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
@@ -68,48 +68,50 @@ export const SingleSelectSearchable = () => {
         {...getToggleButtonProps()}
         className="neo-multiselect-combo__header"
       >
-        {selectedItems[0] && (
-          <Chip
-            closable
-            closeButtonAriaLabel={`Remove ${selectedItems[0].children}`}
-            onClose={(e) => {
-              e.stopPropagation();
-              reset();
+        <span className="neo-padded-container">
+          {selectedItems[0] && (
+            <Chip
+              closable
+              closeButtonAriaLabel={`Remove ${selectedItems[0].children}`}
+              onClose={(e) => {
+                e.stopPropagation();
+                reset();
+              }}
+            >
+              {selectedItems[0].children}
+            </Chip>
+          )}
+
+          <input
+            {...restInputProps}
+            className="neo-input neo-input__height-26px"
+            disabled={disabled}
+            placeholder={placeholder}
+            onKeyDown={(e) => {
+              if (
+                e.key === Keys.ENTER &&
+                filteredOptions.length === 1 &&
+                !filteredOptions[0].disabled
+              ) {
+                e.preventDefault();
+                selectItem(filteredOptions[0]);
+                closeMenu();
+              } else if (e.key === Keys.BACKSPACE && inputValue.length === 0) {
+                reset();
+              }
+
+              onKeyDown(e);
             }}
-          >
-            {selectedItems[0].children}
-          </Chip>
-        )}
+          />
 
-        <input
-          {...restInputProps}
-          className="neo-input"
-          disabled={disabled}
-          placeholder={placeholder}
-          onKeyDown={(e) => {
-            if (
-              e.key === Keys.ENTER &&
-              filteredOptions.length === 1 &&
-              !filteredOptions[0].disabled
-            ) {
-              e.preventDefault();
-              selectItem(filteredOptions[0]);
-              closeMenu();
-            } else if (e.key === Keys.BACKSPACE && inputValue.length === 0) {
-              reset();
-            }
-
-            onKeyDown(e);
-          }}
-        />
-
-        <input
-          className="neo-display-none"
-          id={id}
-          readOnly
-          tabIndex={-1}
-          value={selectedItems[0]?.value || ""}
-        />
+          <input
+            className="neo-display-none"
+            id={id}
+            readOnly
+            tabIndex={-1}
+            value={selectedItems[0]?.value || ""}
+          />
+        </span>
       </span>
 
       <div

--- a/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
@@ -11,7 +11,7 @@ import { SelectContext } from "../utils/SelectContext";
 import { SelectOptionProps } from "../utils/SelectTypes";
 import { OptionsWithEmptyMessageFallback } from "./OptionsWithEmptyMessageFallback";
 
-const logger = log.getLogger("single-select-searchabel");
+const logger = log.getLogger("single-select-searchable");
 logger.disableAll();
 
 export const SingleSelectSearchable = () => {
@@ -115,7 +115,10 @@ export const SingleSelectSearchable = () => {
       </span>
 
       <div
-        className="neo-multiselect__content"
+        className={clsx(
+          "neo-multiselect__content",
+          isOpen && "neo-set-keyboard-focus"
+        )}
         aria-label={ariaLabel}
         {...getMenuProps()}
       >

--- a/src/components/Select/Select_shim.css
+++ b/src/components/Select/Select_shim.css
@@ -130,7 +130,7 @@ div.neo-multiselect.neo-multiselect--small span.neo-multiselect-combo__header {
   padding: 0;
 }
 
-.neo-multiselect-combo__header input.neo-input__height-26px {
+.neo-multiselect-combo__header input.neo-input--height-26px {
   min-height: 26px;
   height: 26px;
   padding-left: 0;

--- a/src/components/Select/Select_shim.css
+++ b/src/components/Select/Select_shim.css
@@ -12,7 +12,7 @@
 body .neo-multiselect__content.neo-set-keyboard-focus,
 body .neo-multiselect__content:focus-visible {
   outline-offset: 1px;
-  outline: 1px auto #1473e6;
+  outline: 1px auto var(--global-outline-color);
 }
 .neo-multiselect__content:empty {
   border: none;
@@ -78,13 +78,12 @@ div.neo-multiselect button.neo-multiselect__header {
   flex-grow: 1;
 }
 
-span.neo-multiselect-combo__header .neo-padded-container {
+span.neo-multiselect-combo__header .neo-multiselect__padded-container {
   align-items: center;
   background-color: var(--input-background-color);
   color: var(--input-font-color);
-  border: 0px solid var(--input-border-color);
+  border: 0;
   letter-spacing: 0;
-  border-radius: 2px;
   flex-wrap: wrap;
   justify-content: flex-start;
   min-height: 36px;
@@ -96,7 +95,7 @@ span.neo-multiselect-combo__header .neo-padded-container {
 
 .neo-multiselect.neo-multiselect--disabled
   .neo-multiselect-combo__header
-  .neo-padded-container {
+  .neo-multiselect__padded-container {
   background-color: var(--input-disabled-bg);
   color: var(--input-disabled-color) !important;
   cursor: not-allowed !important;
@@ -121,16 +120,17 @@ div.neo-multiselect.neo-multiselect--small span.neo-multiselect-combo__header {
   padding-bottom: 0;
 }
 
+/* multiselect button */
 .neo-multiselect
   span.neo-multiselect-combo__header
-  button.neo-multiselect__header.neo-button--width-10px {
+  button.neo-multiselect__header:last-child {
   width: 10px;
   min-height: 30px;
   height: 30px; /* same as chip */
   padding: 0;
 }
-
-.neo-multiselect-combo__header input.neo-input--height-26px {
+/* searchable auto resize input */
+.neo-multiselect-combo__header span input:first-child {
   min-height: 26px;
   height: 26px;
   padding-left: 0;

--- a/src/components/Select/Select_shim.css
+++ b/src/components/Select/Select_shim.css
@@ -9,7 +9,11 @@
   button.neo-multiselect__header.neo-multiselect__header--no-after:after {
   display: none;
 }
-
+body .neo-multiselect__content.neo-set-keyboard-focus,
+body .neo-multiselect__content:focus-visible {
+  outline-offset: 1px;
+  outline: 1px auto #1473e6;
+}
 .neo-multiselect__content:empty {
   border: none;
   box-shadow: none;
@@ -65,11 +69,39 @@
   padding-left: 32px;
   background-color: #f1f1f1;
 }
-div.neo-multiselect button.neo-multiselect__header,
 div.neo-multiselect span.neo-multiselect-combo__header {
-  width: 100%;
   min-height: 36px;
 }
+
+div.neo-multiselect button.neo-multiselect__header {
+  min-height: 36px;
+  flex-grow: 1;
+}
+
+span.neo-multiselect-combo__header .neo-padded-container {
+  align-items: center;
+  background-color: var(--input-background-color);
+  color: var(--input-font-color);
+  border: 0px solid var(--input-border-color);
+  letter-spacing: 0;
+  border-radius: 2px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  min-height: 36px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  flex-grow: 1;
+  display: flex;
+}
+
+.neo-multiselect.neo-multiselect--disabled
+  .neo-multiselect-combo__header
+  .neo-padded-container {
+  background-color: var(--input-disabled-bg);
+  color: var(--input-disabled-color) !important;
+  cursor: not-allowed !important;
+}
+
 div.neo-multiselect.neo-multiselect--small button.neo-multiselect__header,
 div.neo-multiselect.neo-multiselect--small span.neo-multiselect-combo__header {
   width: 100%;
@@ -87,6 +119,22 @@ div.neo-multiselect.neo-multiselect--small span.neo-multiselect-combo__header {
 /* remove innapropriate padding */
 .neo-multiselect .neo-multiselect__content .neo-input-group {
   padding-bottom: 0;
+}
+
+.neo-multiselect
+  span.neo-multiselect-combo__header
+  button.neo-multiselect__header.neo-button--width-10px {
+  width: 10px;
+  min-height: 30px;
+  height: 30px; /* same as chip */
+  padding: 0;
+}
+
+.neo-multiselect-combo__header input.neo-input__height-26px {
+  min-height: 26px;
+  height: 26px;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .neo-multiselect__content .neo-option + .neo-input-hint {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,6 +3516,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-input-autosize@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/react-input-autosize/-/react-input-autosize-2.2.1.tgz#6a335212e7fce1e1a4da56ae2095c8c5c35fbfe6"
+  integrity sha512-RxzEjd4gbLAAdLQ92Q68/AC+TfsAKTc4evsArUH1aIShIMqQMIMjsxoSnwyjtbFTO/AGIW/RQI94XSdvOxCz/w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-table@^7.7.12":
   version "7.7.12"
   resolved "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.12.tgz"
@@ -10890,7 +10897,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11266,6 +11273,13 @@ react-frame-component@^5.2.1:
   version "5.2.3"
   resolved "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.2.3.tgz"
   integrity sha512-r+h0o3r/uqOLNT724z4CRVkxQouKJvoi3OPfjqWACD30Y87rtEmeJrNZf1WYPGknn1Y8200HAjx7hY/dPUGgmA==
+
+react-input-autosize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
+  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-inspector@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
[Select](https://deploy-preview-113--neo-react-library-storybook.netlify.app/?path=/story/components-select--basic-selects)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

fixed 3 issues mentioned in the ticket:
* Spacing issues on all multiple select versions. When there are multiple chips selected, the top padding should match the version that only has a single chip.
* On multiple select, the cursor should be positioned next to the last chip rather than on a new separate line.
* hover state should not cut off focus blue border.

I have also forced focus visible on mouse click, as I want to a consistent look between mouse and keyboard actions.  Let me know if this is ok.