### PR TITLE
Update Tooltip component to allow additional props

### DIFF
--- a/src/components/Pagination/Pagination.test.jsx
+++ b/src/components/Pagination/Pagination.test.jsx
@@ -107,15 +107,16 @@ describe("Pagination", () => {
         >
           <div
             class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
+            id="pagination-item-display-Item count"
           >
             <div
-              aria-describedby="pagination-item-display-Item count"
+              aria-describedby=":rc:"
             >
               1-1 / 10
             </div>
             <div
               class="neo-tooltip__content neo-tooltip__content--multiline"
-              id="pagination-item-display-Item count"
+              id=":rc:"
               role="tooltip"
             >
               <div
@@ -167,9 +168,10 @@ describe("Pagination", () => {
           </nav>
           <div
             class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
+            id="pagination-items-per-page-selection-items per page"
           >
             <div
-              aria-describedby="pagination-items-per-page-selection-items per page"
+              aria-describedby=":rd:"
             >
               <label>
                 Show: 
@@ -197,7 +199,7 @@ describe("Pagination", () => {
             </div>
             <div
               class="neo-tooltip__content neo-tooltip__content--multiline"
-              id="pagination-items-per-page-selection-items per page"
+              id=":rd:"
               role="tooltip"
             >
               <div

--- a/src/components/Tooltip/Tooltip.test.jsx
+++ b/src/components/Tooltip/Tooltip.test.jsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/testing-react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { vi } from "vitest";
 
@@ -61,6 +61,30 @@ describe("Tooltip", () => {
     const { container } = render(<Tooltip label="text">text</Tooltip>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it("accepts props for the wrapper div and the tooltip div", () => {
+    const dataTestId = "example-data-testid";
+    const wrapperClassName = "example-class";
+    const tooltipClassName = "example-tooltip-class";
+
+    render(
+      <Tooltip
+        label="default tooltip text"
+        data-testid={dataTestId}
+        className={wrapperClassName}
+        tooltipDivProps={{ className: tooltipClassName }}
+      >
+        ping
+      </Tooltip>
+    );
+
+    expect(
+      screen.getByTestId(dataTestId).classList.contains(wrapperClassName)
+    ).toBe(true);
+    expect(
+      screen.getByRole("tooltip").classList.contains(tooltipClassName)
+    ).toBe(true);
   });
 
   describe("`aria-describedby` functionality", () => {

--- a/src/components/Tooltip/Tooltip.test.jsx
+++ b/src/components/Tooltip/Tooltip.test.jsx
@@ -36,15 +36,16 @@ describe("Tooltip", () => {
       <div>
         <div
           class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
+          id="example"
         >
           <div
-            aria-describedby="example"
+            aria-describedby=":r1:"
           >
             text
           </div>
           <div
             class="neo-tooltip__content neo-tooltip__content--multiline"
-            id="example"
+            id=":r1:"
             role="tooltip"
           >
             <div
@@ -88,13 +89,17 @@ describe("Tooltip", () => {
   });
 
   describe("`aria-describedby` functionality", () => {
-    const id = "exampleid";
-    const idProp = `id="${id}"`;
-    const ariaProp = `aria-describedby="${id}"`;
+    const tooltipDivId = "exampleid";
+    const idProp = `id="${tooltipDivId}"`;
+    const ariaProp = `aria-describedby="${tooltipDivId}"`;
 
     it("applies an `aria-describedby` to a plain text child", () => {
       const { container } = render(
-        <Tooltip id={id} label="default tooltip text" position="top">
+        <Tooltip
+          tooltipDivProps={{ id: tooltipDivId }}
+          label="default tooltip text"
+          position="top"
+        >
           text
         </Tooltip>
       );
@@ -127,7 +132,11 @@ describe("Tooltip", () => {
 
     it("applies an `aria-describedby` to a single react element", () => {
       const { container } = render(
-        <Tooltip id={id} label="default tooltip text" position="top">
+        <Tooltip
+          tooltipDivProps={{ id: tooltipDivId }}
+          label="default tooltip text"
+          position="top"
+        >
           <p>text</p>
         </Tooltip>
       );
@@ -160,7 +169,11 @@ describe("Tooltip", () => {
 
     it("applies an `aria-describedby` to an array of react elements", () => {
       const { container } = render(
-        <Tooltip id={id} label="default tooltip text" position="top">
+        <Tooltip
+          tooltipDivProps={{ id: tooltipDivId }}
+          label="default tooltip text"
+          position="top"
+        >
           <ul>
             <li>item one</li>
             <li>item two</li>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -42,7 +42,6 @@ export const Tooltip = ({
   arrow = true,
   children,
   className,
-  id,
   label,
   multiline,
   position = "auto",
@@ -51,7 +50,7 @@ export const Tooltip = ({
   ...rest
 }: TooltipProps) => {
   const generatedId = useId();
-  id = id || generatedId;
+  const tooltipId = tooltipDivProps?.id || generatedId;
   const tooltipContainerRef = useRef(null);
 
   const [tooltipPosition, setTooltipPosition] = useState("");
@@ -78,12 +77,12 @@ export const Tooltip = ({
   const wrappedChildren = useMemo(() => {
     const shouldWrap = isString(children) || Children.count(children) > 1;
     if (shouldWrap) {
-      return <div aria-describedby={id}>{children}</div>;
+      return <div aria-describedby={tooltipId}>{children}</div>;
     }
 
     const child = Children.only(children) as React.ReactElement;
-    return cloneElement(child, { "aria-describedby": id });
-  }, [children, id]);
+    return cloneElement(child, { "aria-describedby": tooltipId });
+  }, [children, tooltipId]);
 
   const [allowTooltip, setAllowTooltip] = useState(true);
   const setAllowTooltipTrue = useCallback(
@@ -136,13 +135,13 @@ export const Tooltip = ({
 
       <div
         {...tooltipDivProps}
+        id={tooltipId}
+        role="tooltip"
         className={clsx(
           "neo-tooltip__content",
           multilineClassName,
           tooltipDivProps?.className
         )}
-        role="tooltip"
-        id={id}
       >
         {arrow && <div className="neo-arrow" />}
         {label}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -46,6 +46,7 @@ export const Tooltip = ({
   label,
   multiline,
   position = "auto",
+  tooltipDivProps,
 
   ...rest
 }: TooltipProps) => {
@@ -134,7 +135,12 @@ export const Tooltip = ({
       {wrappedChildren}
 
       <div
-        className={clsx("neo-tooltip__content", multilineClassName)}
+        {...tooltipDivProps}
+        className={clsx(
+          "neo-tooltip__content",
+          multilineClassName,
+          tooltipDivProps?.className
+        )}
         role="tooltip"
         id={id}
       >

--- a/src/components/Tooltip/TooltipTypes.ts
+++ b/src/components/Tooltip/TooltipTypes.ts
@@ -27,5 +27,5 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   multiline?: boolean;
   position?: TooltipPosition;
 
-  tooltipDivProps?: Exclude<HTMLAttributes<HTMLDivElement>, "role" | "id">;
+  tooltipDivProps?: Exclude<HTMLAttributes<HTMLDivElement>, "role">;
 }

--- a/src/components/Tooltip/TooltipTypes.ts
+++ b/src/components/Tooltip/TooltipTypes.ts
@@ -26,4 +26,6 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   label: string;
   multiline?: boolean;
   position?: TooltipPosition;
+
+  tooltipDivProps?: Exclude<HTMLAttributes<HTMLDivElement>, "role" | "id">;
 }


### PR DESCRIPTION
[Link to Tooltip story](https://deploy-preview-119--neo-react-library-storybook.netlify.app/?path=/story/components-tooltip--default), [Link to Pagination story](https://deploy-preview-119--neo-react-library-storybook.netlify.app/?path=/story/components-pagination--default) (tooltip is on the "Item count" and "Items per page" select)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

On the update DPv3 Tooltip Page, the "left" and "right" tooltips pass over the containing border. It _should_ be simple to add a class/style to the tooltip to set a proper width to fix that visual issue. It isn't currently, thus this change. 

I've added the prop `tooltipDivProps` to allow the Tooltip so that the implementor can add/edit whatever they wish. Excluding the `role` prop, as that would break the a11y (and a bunch of other ish). As a part of that, I moved the current `id` to be the id of the wrapper div, which is more consistent with the rest of our props as all the other props only affect the wrapper. That change forced me to make a few minor test updates. The test updates are only moving the placement of the `id` prop. 

I also added one test to ensure that props are being passed around correctly. 
