### PR TITLE
fix Voice Over announcing "object object selected" issue

### DIFF
--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -22,7 +22,6 @@ const DownshiftWithComboboxProps = (
   creatable: boolean,
   createMessage: string
 ) => {
-  // HACK: `onSelectedItemChange`'s `inputValue` is always `[object Object]`, no idea why
   const [inputText, setInputText] = useState("");
 
   return useCombobox({
@@ -82,6 +81,7 @@ const DownshiftWithComboboxProps = (
         setSelectedItems([clickedItem]);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -197,6 +197,7 @@ const DownshiftWithComboboxMultipleSelectProps = (
         setFilteredOptions(options);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -230,6 +231,7 @@ const DownshiftWithSelectProps = (
         setSelectedItems([selectedItem]);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -298,6 +300,7 @@ const DownshiftWithMultipleSelectProps = (
         setSelectedItems([...selectedItems, selectedItem]);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -81,7 +81,6 @@ const DownshiftWithComboboxProps = (
         setSelectedItems([clickedItem]);
       }
     },
-    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -300,7 +299,6 @@ const DownshiftWithMultipleSelectProps = (
         setSelectedItems([...selectedItems, selectedItem]);
       }
     },
-    itemToString: (item) => item?.value || "",
   });
 };
 

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -81,6 +81,7 @@ const DownshiftWithComboboxProps = (
         setSelectedItems([clickedItem]);
       }
     },
+    // BUG: items are not announced in screen reader when selected
   });
 };
 
@@ -299,6 +300,7 @@ const DownshiftWithMultipleSelectProps = (
         setSelectedItems([...selectedItems, selectedItem]);
       }
     },
+    // BUG: items are not announced in screen reader when selected
   });
 };
 


### PR DESCRIPTION
[Link to updated Select Component](https://deploy-preview-123--neo-react-library-storybook.netlify.app/?path=/story/components-select--basic-selects)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

There are several a11y issues with the Select components. For this PR, I am _only_ fixing one small thing. 

**BUG**: When an item is selected, Voice Over announces the selected item as "object object has been selected".
**FIX**: I've fixed this by specifying the `itemToString` in the downshift configs. 

NOTE: there are two types of select that do not announce the selected item at all. I've added `// BUG:` to those methods. 
