### PR TITLE
only set aria label as aria label (double speak fix)

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -178,7 +178,7 @@ export const Select = (props: SelectProps) => {
   const contextValue = {
     downshiftProps,
     selectProps: {
-      ariaLabel: ariaLabel || label,
+      ariaLabel,
       disabled,
       filteredOptions,
       helperId,

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -22,7 +22,6 @@ const DownshiftWithComboboxProps = (
   creatable: boolean,
   createMessage: string
 ) => {
-  // HACK: `onSelectedItemChange`'s `inputValue` is always `[object Object]`, no idea why
   const [inputText, setInputText] = useState("");
 
   return useCombobox({
@@ -82,6 +81,7 @@ const DownshiftWithComboboxProps = (
         setSelectedItems([clickedItem]);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -197,6 +197,7 @@ const DownshiftWithComboboxMultipleSelectProps = (
         setFilteredOptions(options);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -230,6 +231,7 @@ const DownshiftWithSelectProps = (
         setSelectedItems([selectedItem]);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -298,6 +300,7 @@ const DownshiftWithMultipleSelectProps = (
         setSelectedItems([...selectedItems, selectedItem]);
       }
     },
+    itemToString: (item) => item?.value || "",
   });
 };
 

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -81,7 +81,6 @@ const DownshiftWithComboboxProps = (
         setSelectedItems([clickedItem]);
       }
     },
-    itemToString: (item) => item?.value || "",
   });
 };
 
@@ -300,7 +299,6 @@ const DownshiftWithMultipleSelectProps = (
         setSelectedItems([...selectedItems, selectedItem]);
       }
     },
-    itemToString: (item) => item?.value || "",
   });
 };
 

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -81,6 +81,7 @@ const DownshiftWithComboboxProps = (
         setSelectedItems([clickedItem]);
       }
     },
+    // BUG: items are not announced in screen reader when selected
   });
 };
 
@@ -299,6 +300,7 @@ const DownshiftWithMultipleSelectProps = (
         setSelectedItems([...selectedItems, selectedItem]);
       }
     },
+    // BUG: items are not announced in screen reader when selected
   });
 };
 


### PR DESCRIPTION
**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

Like [this PR's sibling](https://github.com/avaya-dux/neo-react-library/pull/123), there are several a11y issues with the Select components. For this PR, I am only fixing one small thing.

**BUG**: when a user using a screen reader enters a Select component, the label is read twice. This is because the label _and_ the aria-label are both being read (which is correct).
**FIX**: I'm no longer forcefully setting an aria-label. Now, I only set it if there is one that is passed. 
