### PR TITLE
resolve design portal build issue (on Netlify)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaya/neo-react",
-  "version": "0.7.20",
+  "version": "0.8.0",
   "description": "This is the React version of the shared library called 'NEO' buit by Avaya",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "github:avaya-dux/neo-react-library",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "LICENSE-3rd-party.html"
   ],
   "engines": {
-    "node": "16"
+    "node": ">=16"
   },
   "browserslist": [
     "> 0.5%",


### PR DESCRIPTION
By pinning the "engine" we simplified the dev experience for running neo-react, but we did not realize it forces all projects using neo-react to also use the engine version. Thus, updating engine version to allow all node versions 16+.

Also, looks like `0.7.20` has already been used, and it makes sense to update the minor version as we've done so much work. Thus updating the package version to `0.8.0`.