### PR TITLE
pin node version for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,4 +9,6 @@
   rangeStrategy: "pin", // pin dependencies
   reviewers: ["mrazian85", "joe-s-avaya", "enrique-prado", "yangAtSpoken"],
   schedule: ["on monday before 5am"],
+  ignoreDeps: ["node"],
+  ignorePaths: ["~/.nvmrc"],
 }


### PR DESCRIPTION
This update _should_ keep [this PR](https://github.com/avaya-dux/neo-react-library/pull/200) from happening repeatedly. Specifically:

- keeps renovate from updating `.nvmrc`
- keeps renovate from updating `package.json`s `engines.node` (if the current config doesn't work, [we can try this suggestion](https://github.com/renovatebot/renovate/discussions/13521#discussioncomment-1958929))