### PR TITLE
set `autodocs` back to `true`

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,7 +24,7 @@ const config: StorybookConfig = {
     });
   },
   docs: {
-    autodocs: "tag",
+    autodocs: true,
   },
 };
 export default config;


### PR DESCRIPTION
[Link to Accordion "docs" page](https://deploy-preview-216--neo-react-library-storybook.netlify.app/?path=/docs/components-accordion--docs)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

Storybook v7 now has a config setting for auto generating documents. When I updated to v7 I set the wrong value, this fixes that so that now _all_ stories have autodocs, as they were before the v7 update. 

Components now have a auto generated "Docs" story:
![Screenshot 2023-06-24 at 6 03 48 PM](https://github.com/avaya-dux/neo-react-library/assets/55896546/9bc25a76-a10b-470d-9d49-e62da30432e3)
