### PR TITLE
Fixed type issue w/ Timer, fixed Cypress warnings re: excessive linking of methods

### DIFF
--- a/src/components/AgentCard/Timer.tsx
+++ b/src/components/AgentCard/Timer.tsx
@@ -6,7 +6,7 @@ export interface TimerProps {
 
 export const Timer = ({ agentStatus }: TimerProps) => {
   const [count, setCount] = useState(0);
-  const timerIdRef = useRef<undefined | NodeJS.Timer>(undefined);
+  const timerIdRef = useRef<undefined | NodeJS.Timeout>(undefined);
   const hour: number = Math.floor(count / 3600);
   const minute: number = Math.floor((count - hour * 3600) / 60);
   const seconds: number = count - (hour * 3600 + minute * 60);

--- a/src/components/Pagination/Pagination.cypresstest.tsx
+++ b/src/components/Pagination/Pagination.cypresstest.tsx
@@ -45,27 +45,37 @@ describe("Pagination component", () => {
 
     cy.get(navItems).last().click();
 
-    cy.focused().should("have.text", "20");
+    cy.focused();
 
-    cy.get(navItems).first().click();
+    cy.should("have.text", "20");
 
-    cy.focused().should("have.text", "1");
+    cy.get(navItems);
+
+    cy.first().click();
+
+    cy.focused();
+
+    cy.should("have.text", "1");
   });
 
   it("should navigate smoothly via tabbing", () => {
     cy.mount(<Default />);
 
-    cy.get("#default-pagination").click();
+    cy.get("#default-pagination");
+    cy.click();
     cy.realPress("Tab"); // 1
     cy.realPress("Tab"); // 2
     cy.realPress("Tab"); // 3
     cy.realPress("Enter");
-    cy.focused().should("have.text", "3");
+    cy.focused();
+    cy.should("have.text", "3");
 
     cy.realPress(["Shift", "Tab"]); // 2
     cy.realPress(["Shift", "Tab"]); // 1
     cy.realPress("Enter");
 
-    cy.focused().should("have.text", "1");
+    cy.focused();
+
+    cy.should("have.text", "1");
   });
 });


### PR DESCRIPTION
Fixing two issues that are causing a `renovate` PR to fail:

1) A type issue in the `src/components/AgentCard/Timer.tsx` file -- confirmed Component Story still working
2) Fixed linting errors related to chaining multiple methods off a single call to `cy.` in Cypress test file
