### PR TITLE
NEO-1482 stop parent of vertical tabs from scrolling on arrow-down and arrow-up events

### DIFF
--- a/src/components/Tab/EventHandlers/KeyboardEventHandlers.test.jsx
+++ b/src/components/Tab/EventHandlers/KeyboardEventHandlers.test.jsx
@@ -77,7 +77,7 @@ describe("Tab Keyboard event handlers", () => {
     describe(Keys.DOWN, () => {
       let e;
       beforeEach(() => {
-        e = { key: Keys.DOWN, stopPropagation: vi.fn() };
+        e = { key: Keys.DOWN, stopPropagation: vi.fn(), preventDefault: vi.fn() };
       });
       afterEach(() => {
         vi.resetAllMocks();
@@ -123,6 +123,7 @@ describe("Tab Keyboard event handlers", () => {
           ref,
         );
         expect(setActiveTabIndex).toBeCalled();
+        expect(e.preventDefault).toBeCalled();
       });
       it("should do nothing if next tab does not exist  and tab layout is vertical", () => {
         const tabs = getTabProps();
@@ -137,6 +138,7 @@ describe("Tab Keyboard event handlers", () => {
           ref,
         );
         expect(setActiveTabIndex).not.toBeCalled();
+        expect(e.preventDefault).toBeCalled();
       });
     });
     describe(Keys.UP, () => {

--- a/src/components/Tab/EventHandlers/KeyboardEventHandlers.ts
+++ b/src/components/Tab/EventHandlers/KeyboardEventHandlers.ts
@@ -130,11 +130,15 @@ export const handleKeyDownEvent = (
       break;
     case Keys.DOWN:
       if (isTabListVertical) {
+        // prevent default scrolling
+        e.preventDefault();
         activateNextTab(tabs, activeTabIndex, setActiveTabIndex);
       }
       break;
     case Keys.UP:
       if (isTabListVertical) {
+        // prevent default scrolling
+        e.preventDefault();
         activatePreviousTab(tabs, activeTabIndex, setActiveTabIndex);
       }
       break;

--- a/src/components/Tab/Tabs.stories.tsx
+++ b/src/components/Tab/Tabs.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { Button } from "components";
 
-import { tabMouseEventHandlerLogger } from "./EventHandlers";
+import { tabMouseEventHandlerLogger, tabKeyboardEventHandler } from "./EventHandlers";
 import {
   ClosableTab,
   Tab,
@@ -15,7 +15,8 @@ import {
 import { Tabs } from "./Tabs";
 import { TabsProps } from "./TabTypes";
 
-tabMouseEventHandlerLogger.enableAll();
+tabMouseEventHandlerLogger.disableAll();
+tabKeyboardEventHandler.enableAll();
 
 export default {
   title: "Components/Tab",


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-258--neo-react-library-storybook.netlify.app/?path=/story/components-tab--scrollable-vertical-tabs)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

As described in title