### PR TITLE
allow user to pass a `key` for all Tab components

### DIFF
--- a/src/components/Tab/TabTypes.tsx
+++ b/src/components/Tab/TabTypes.tsx
@@ -5,6 +5,7 @@ import { IconNamesType } from "utils";
 
 export interface TabProps extends React.HTMLAttributes<HTMLDivElement> {
   id?: string;
+  key?: string;
   children: ReactNode;
   disabled?: boolean;
   icon?: IconNamesType;


### PR DESCRIPTION
as all members of an array must have a `key` prop passed for the react compiler

this was found as part of the updates to DPv3