### PR TITLE
NEO-1910: Text input required prop not working

### DIFF
--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -40,6 +40,7 @@ export const DifferentHTMLOutputExamples = () => {
           label="Input type password"
           placeholder="Placeholder password"
           type="password"
+          required
         />
 
         <TextInput
@@ -212,8 +213,9 @@ export const TypeSwitch = () => {
     <Form>
       <TextInput
         label="Text Input"
-        defaultValue="Try To Change Me"
+        defaultValue="Now I'm a simple input."
         type={type}
+        required
       />
       <Checkbox
         onChange={toggle}

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -22,8 +22,10 @@ export const Default = () => {
 
 export const DifferentHTMLOutputExamples = () => {
   return (
-    <section>
+    <section className="neo-form">
       <TextInput label="Just a Label" />
+
+      <TextInput required label="This is required" />
 
       <TextInput
         label="With start adorment icon"

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from "@storybook/react";
 
-import { Checkbox, Icon } from "components";
+import { Checkbox, Form, Icon } from "components";
 
 import { TextInput, TextInputProps } from "./TextInput";
 import { useCallback, useState } from "react";
@@ -12,144 +12,158 @@ export default {
 
 export const Default = () => {
   return (
-    <TextInput
-      label="Example Field"
-      placeholder="Hello World..."
-      helperText="Some helper text."
-    />
+    <Form>
+      <TextInput
+        label="Example Field"
+        placeholder="Hello World..."
+        helperText="Some helper text."
+      />
+    </Form>
   );
 };
 
 export const DifferentHTMLOutputExamples = () => {
   return (
-    <section className="neo-form">
-      <TextInput label="Just a Label" />
+    <section>
+      <Form>
+        <TextInput label="Just a Label" />
 
-      <TextInput required label="This is required" />
+        <TextInput required label="This is required" />
 
-      <TextInput
-        label="With start adorment icon"
-        placeholder="Placeholder text"
-        startAddon={<Icon icon="star-filled" aria-label="input icon" />}
-      />
+        <TextInput
+          label="With start adorment icon"
+          placeholder="Placeholder text"
+          startAddon={<Icon icon="star-filled" aria-label="input icon" />}
+        />
 
-      <TextInput
-        label="Input type password"
-        placeholder="Placeholder password"
-        type="password"
-      />
+        <TextInput
+          label="Input type password"
+          placeholder="Placeholder password"
+          type="password"
+        />
 
-      <TextInput
-        label="Input type email"
-        placeholder="Placeholder email"
-        type="email"
-      />
+        <TextInput
+          label="Input type email"
+          placeholder="Placeholder email"
+          type="email"
+        />
 
-      <TextInput
-        label="Input type number"
-        placeholder="Placeholder number"
-        type="number"
-      />
+        <TextInput
+          label="Input type number"
+          placeholder="Placeholder number"
+          type="number"
+        />
 
-      <TextInput
-        label="Input type tel"
-        placeholder="Placeholder tel"
-        type="tel"
-      />
+        <TextInput
+          label="Input type tel"
+          placeholder="Placeholder tel"
+          type="tel"
+        />
 
-      <TextInput
-        label="Input type text"
-        placeholder="Placeholder text"
-        type="text"
-      />
+        <TextInput
+          label="Input type text"
+          placeholder="Placeholder text"
+          type="text"
+        />
 
-      <TextInput
-        label="With start icon"
-        placeholder="Placeholder text"
-        startIcon="star-filled"
-      />
+        <TextInput
+          label="With start icon"
+          placeholder="Placeholder text"
+          startIcon="star-filled"
+        />
 
-      <TextInput defaultValue="Try To Change Me" disabled label="Disabled" />
+        <TextInput defaultValue="Try To Change Me" disabled label="Disabled" />
 
-      <TextInput
-        defaultValue="Try To Change Me"
-        disabled
-        label="Disabled with ending icon"
-        startIcon="do-not-disturb-filled"
-      />
+        <TextInput
+          defaultValue="Try To Change Me"
+          disabled
+          label="Disabled with ending icon"
+          startIcon="do-not-disturb-filled"
+        />
 
-      <TextInput
-        defaultValue="readonly value"
-        label="Read Only"
-        placeholder="Placeholder text"
-        readOnly
-      />
+        <TextInput
+          defaultValue="readonly value"
+          label="Read Only"
+          placeholder="Placeholder text"
+          readOnly
+        />
 
-      <br />
-      <p style={{ fontSize: "14pt" }}> Small size variants</p>
-      <br />
+        <br />
+        <p style={{ fontSize: "14pt" }}> Small size variants</p>
+        <br />
 
-      <TextInput
-        label="Small size (basic)"
-        isSmall
-        placeholder="Placeholder text"
-      />
+        <TextInput
+          label="Small size (basic)"
+          isSmall
+          placeholder="Placeholder text"
+        />
 
-      <br />
+        <br />
 
-      <TextInput
-        label="Small size (disabled)"
-        isSmall
-        disabled
-        defaultValue="Try to change me"
-      />
+        <TextInput
+          label="Small size (disabled)"
+          isSmall
+          disabled
+          defaultValue="Try to change me"
+        />
 
-      <br />
+        <br />
 
-      <TextInput
-        label="Small size (type password)"
-        placeholder="Placeholder password"
-        type="password"
-        isSmall
-      />
+        <TextInput
+          label="Small size (type password)"
+          placeholder="Placeholder password"
+          type="password"
+          isSmall
+        />
+      </Form>
     </section>
   );
 };
 
 export const ErrorState = () => {
   return (
-    <TextInput error label="Name" helperText="Name is required." required />
+    <Form>
+      <TextInput error label="Name" helperText="Name is required." required />
+    </Form>
   );
 };
 
 export const AdornmentIcons = () => {
   return (
-    <TextInput
-      label="Icon Add Ons"
-      startAddon={<Icon icon="call" aria-label="input icon" />}
-      endAddon={<Icon icon="call" aria-label="input icon" />}
-    />
+    <Form>
+      <TextInput
+        label="Icon Add Ons"
+        startAddon={<Icon icon="call" aria-label="input icon" />}
+        endAddon={<Icon icon="call" aria-label="input icon" />}
+      />
+    </Form>
   );
 };
 
 export const AdornmentStrings = () => {
-  return <TextInput label="Domain" startAddon="www." endAddon=".com" />;
+  return (
+    <Form>
+      <TextInput label="Domain" startAddon="www." endAddon=".com" />
+    </Form>
+  );
 };
 
 export const Clearable = () => {
   return (
-    <TextInput
-      label="Clearable Field"
-      defaultValue="Initial Value"
-      clearable
-      helperText="Click the clear icon inside the input."
-    />
+    <Form>
+      <TextInput
+        label="Clearable Field"
+        defaultValue="Initial Value"
+        clearable
+        helperText="Click the clear icon inside the input."
+      />
+    </Form>
   );
 };
 
 export const ReadOnly = () => {
   return (
-    <>
+    <Form>
       <TextInput label="Read Only" defaultValue="Try To Change Me" readOnly />
 
       <TextInput
@@ -158,13 +172,13 @@ export const ReadOnly = () => {
         startAddon="+1"
         readOnly
       />
-    </>
+    </Form>
   );
 };
 
 export const Disabled = () => {
   return (
-    <>
+    <Form>
       <TextInput label="Disabled" defaultValue="Try To Change Me" disabled />
       <TextInput
         label="Clearable But Disabled"
@@ -173,12 +187,16 @@ export const Disabled = () => {
         startAddon="+1"
         disabled
       />
-    </>
+    </Form>
   );
 };
 
 export const BadAccessibility = () => {
-  return <TextInput />;
+  return (
+  <Form>
+    <TextInput />
+  </Form>
+  );
 };
 
 export const TypeSwitch = () => {
@@ -191,7 +209,7 @@ export const TypeSwitch = () => {
     }
   }, [type]);
   return (
-    <>
+    <Form>
       <TextInput
         label="Text Input"
         defaultValue="Try To Change Me"
@@ -206,7 +224,7 @@ export const TypeSwitch = () => {
       >
         Type is password
       </Checkbox>
-    </>
+    </Form>
   );
 };
 // TODO: add controlled, uncontrolled, and an "inline" option

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -45,11 +45,16 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
  * They’re used in forms, modal dialogs, tables, and other
  * surfaces where text input is required.
  *
+ * IMPORTANT: The TextInput component is designed to be contained within a
+ * <Form> component in order for all the styles to render correctly.
+ *
  * @example
- * <TextInput label="Just a Label" />
- * <TextInput label="Password" type="password" />
- * <TextInput label="Email" type="email" />
- * <TextInput label="Search" startIcon="search" clearable={true} />
+ * <Form>
+ *  <TextInput label="Just a Label" />
+ *  <TextInput label="Password" type="password" />
+ *  <TextInput label="Email" type="email" />
+ *  <TextInput label="Search" startIcon="search" clearable={true} />
+ * </Form>
  *
  * @see https://design.avayacloud.com/components/web/input-web
  * @see https://neo-react-library-storybook.netlify.app/?path=/story/components-text-input


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-281--neo-react-library-storybook.netlify.app/?path=/story/components-text-input--different-html-output-examples)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred

This PR fixes an issue exposed when our TextInput component has the 'required' prop set to true and it is not properly wrapped inside a 'Form' component. The bug was not in the component itself but in the way it was used.

By wrapping each TextInput story in a Form component, the correct styles and decorators now render correctly. See screenshot that shows the red asterisk next to the label for the required field.

![image](https://github.com/avaya-dux/neo-react-library/assets/3535271/dff0a0ef-adbe-4590-bff1-a6e74b03a095)


