### PR TITLE
NEO-1942 // disallow `placeholder` prop for non-searchable Select

### DIFF
--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -24,7 +24,6 @@ export const MultiSelect = () => {
       helperId,
       helperText,
       loading,
-      placeholder,
       size,
     },
   } = useContext(SelectContext);
@@ -90,7 +89,7 @@ export const MultiSelect = () => {
               className="neo-multiselect__header"
               type="button"
             >
-              {selectedItemsAsChips ? <>&nbsp;</> : placeholder}
+              &nbsp;
             </button>
 
             <button

--- a/src/components/Select/InternalComponents/SingleSelect.tsx
+++ b/src/components/Select/InternalComponents/SingleSelect.tsx
@@ -11,15 +11,7 @@ export const SingleSelect = () => {
   const {
     downshiftProps: { getMenuProps, getToggleButtonProps, isOpen },
     optionProps: { selectedItems, selectedItemsValues },
-    selectProps: {
-      ariaLabel,
-      disabled,
-      helperId,
-      helperText,
-      loading,
-      placeholder,
-      size,
-    },
+    selectProps: { ariaLabel, disabled, helperId, helperText, loading, size },
   } = useContext(SelectContext);
   const {
     role,
@@ -60,7 +52,7 @@ export const SingleSelect = () => {
           className="neo-multiselect__header"
           type="button"
         >
-          {selectedItems[0]?.children || placeholder}
+          {selectedItems[0]?.children}
         </button>
       </span>
 

--- a/src/components/Select/Select.test.jsx
+++ b/src/components/Select/Select.test.jsx
@@ -175,7 +175,6 @@ describe("Select", () => {
 
       it("toggles aria-expanded prop on click", () => {
         const toggleElement = screen.getAllByRole("button")[0];
-        expect(toggleElement).toHaveTextContent(placeholder);
         expect(toggleElement).toHaveAttribute("aria-expanded", "false");
         fireEvent.click(toggleElement);
         expect(toggleElement).toHaveAttribute("aria-expanded", "true");
@@ -275,7 +274,6 @@ describe("Select", () => {
         );
 
         const defaultSelectHeader = getAllByRole("button")[0];
-        expect(defaultSelectHeader).toHaveTextContent(placeholder);
         expect(defaultSelectHeader).toHaveAttribute("aria-expanded", "false");
         fireEvent.click(defaultSelectHeader);
         expect(defaultSelectHeader).toHaveAttribute("aria-expanded", "false");

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -80,6 +80,12 @@ export const Select = (props: SelectProps) => {
     handleAccessbilityError("Select requires a label prop or aria-label");
   }
 
+  if (!searchable && placeholder) {
+    console.warn(
+      `For Select with id ${id}, the placeholder prop is ignored when component is not searchable`,
+    );
+  }
+
   const helperId = useMemo(() => `helper-text-${id}`, [id]);
   const isInitialRender = useIsInitialRender();
 


### PR DESCRIPTION
[Link to Select Storybook](https://deploy-preview-314--neo-react-library-storybook.netlify.app/?path=/story/components-select--basic-selects)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

In [part one](https://github.com/avaya-dux/neo-react-library/pull/311), I fixed the styling for searchable Select components. In this PR I disallow the use of the `placeholder` for non-searchable Select components as [the HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) does not allow placeholder text for the base select element, and [the placeholder prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/placeholder) only exists on text inputs type elements. 
