### PR TITLE
NEO-2100: Notification component's new showTimestamp prop

### DIFF
--- a/src/components/Notification/NonEventNotification.stories.tsx
+++ b/src/components/Notification/NonEventNotification.stories.tsx
@@ -26,6 +26,17 @@ export const Info: Story = {
   },
 };
 
+export const InfoNoTimestamp: Story = {
+  args: {
+    type: "info",
+    header: "Info",
+    description: "This is some info with no timestamp.",
+    showTimestamp: false,
+    isElevated: false,
+    isInline: true,
+  },
+};
+
 export const Success: Story = {
   args: {
     type: "success",

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -84,6 +84,7 @@ export const Notification = ({
   actions,
   header = "",
   description = "",
+  showTimestamp = true,
   isElevated = false,
   isInline = false,
   occurences = 0,
@@ -185,9 +186,11 @@ export const Notification = ({
       />
       <div className="neo-notification__message" ref={notificationRef}>
         <div className="neo-notification__message__wrapper">
-          <p className="neo-notification__timestamp neo-body-small neo-semibold">
+          {showTimestamp && (
+            <p className="neo-notification__timestamp neo-body-small neo-semibold">
             {timestamp}
-          </p>
+            </p>
+          )}
 
           {occurences > 1 && (
             <Tooltip label={clsx(notificationTranslations.badge, occurences)}>

--- a/src/components/Notification/NotificationTypes.tsx
+++ b/src/components/Notification/NotificationTypes.tsx
@@ -19,6 +19,7 @@ type AtLeastOneProps =
   | { header?: string; description: string };
 
 type CommonProps = {
+  showTimestamp?: boolean;
   isElevated?: boolean;
   isInline?: boolean;
   occurences?: number;


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-320--neo-react-library-storybook.netlify.app/?path=/story/components-notification--info-no-timestamp)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

This PR adds a new showTimestamp prop that gives the ability to show or hide the date and time info that appears at the top. Previous this this change it was ALWAYS showing it. We can now hide it by setting the prop to false.

The prop value defaults to true to keep backwards compatibility with any apps currently using this component.  Here's a screenshot of a notification with the Timestamp not showing:
![image](https://github.com/avaya-dux/neo-react-library/assets/3535271/f190a985-5a59-4cdd-9cc6-9aab5a82a85c)

