### PR TITLE
NEO-2103: Fixed broken navigation for default anchor behavior

### DIFF
--- a/src/components/LeftNav/LinkItem/LinkItem.tsx
+++ b/src/components/LeftNav/LinkItem/LinkItem.tsx
@@ -64,8 +64,10 @@ export const LinkItem = ({
   }, [disabled, parentHasIcon]);
 
   const handleOnClick: MouseEventHandler = (e) => {
+    if (ctx.hasCustomOnNavigate) {
+      e.preventDefault(); // Override anchor default behavior if a custom event handler is provided
+    }
     handleClick();
-    e.preventDefault();
     ctx?.onSelectedLink && ctx.onSelectedLink(id as string, href);
   };
 


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-323--neo-react-library-storybook.netlify.app/?path=/story/components-left-navigation--category-groups)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work

This PR fixes an edge case where if no custom navigation handler is given for a LinkItem, it will perform a default anchor navigation. A change to the Portal side navigation exposed this bug I'm now fixing.  BTW, the same has already been made for the TopLinkItem component in a previous PR.


