### PR TITLE
NEO-2218: Exposing Pagination tooltip positioning props in Table component

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -33,6 +33,13 @@ export const Default = () => (
   <Table {...FilledFields} caption="Storybook Default Table Example" />
 );
 
+export const TooltipPositioning = () => (
+  <Table {...FilledFields}
+    itemDisplayTooltipPosition="right"
+    itemsPerPageTooltipPosition="left"
+    caption="Tooltip positioning in Pagination Example" />
+);
+
 export const MoreActionsMenu = () => (
   <Table
     caption="Last column has more actions menu."

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -34,10 +34,12 @@ export const Default = () => (
 );
 
 export const TooltipPositioning = () => (
-  <Table {...FilledFields}
+  <Table
+    {...FilledFields}
     itemDisplayTooltipPosition="right"
     itemsPerPageTooltipPosition="left"
-    caption="Tooltip positioning in Pagination Example" />
+    caption="Tooltip positioning in Pagination Example"
+  />
 );
 
 export const MoreActionsMenu = () => (

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -36,8 +36,8 @@ export const Default = () => (
 export const TooltipPositioning = () => (
   <Table
     {...FilledFields}
-    itemDisplayTooltipPosition="right"
-    itemsPerPageTooltipPosition="left"
+    itemDisplayTooltipPosition="top-right"
+    itemsPerPageTooltipPosition="top-left"
     caption="Tooltip positioning in Pagination Example"
   />
 );

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -83,6 +83,8 @@ export const Table = <T extends Record<string, any>>({
   pushPaginationDown = false,
   showRowSeparator = false,
   showRowHeightMenu = true,
+  itemDisplayTooltipPosition = "auto",
+  itemsPerPageTooltipPosition = "auto",
   translations,
 
   ...rest
@@ -272,6 +274,8 @@ export const Table = <T extends Record<string, any>>({
             tooltipForShownPagesSelect={
               paginationTranslations.tooltipForShownPagesSelect
             }
+            itemDisplayTooltipPosition={itemDisplayTooltipPosition}
+            itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
           />
         )}
       </div>

--- a/src/components/Table/types/TableTypes.ts
+++ b/src/components/Table/types/TableTypes.ts
@@ -9,6 +9,7 @@ import {
   ITableTranslations,
   IToolbarTranslations,
 } from ".";
+import { TooltipPosition } from "components/Tooltip/TooltipTypes";
 
 interface ToolbarSharedProps<T extends Record<string, any>> {
   readonly?: boolean;
@@ -59,6 +60,8 @@ export type TableProps<T extends Record<string, any>> = {
   id?: string;
   showPagination?: boolean;
   pushPaginationDown?: boolean;
+  itemDisplayTooltipPosition?: TooltipPosition;
+  itemsPerPageTooltipPosition?: TooltipPosition;
   itemsPerPageOptions?: number[];
   initialStatePageIndex?: number;
   defaultSelectedRowIds?: string[];


### PR DESCRIPTION
[Tooltip positioning in Deploy Preview](https://deploy-preview-391--neo-react-library-storybook.netlify.app/?path=/story/components-table--tooltip-positioning)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)

This PR adds the ability to position the tooltips for the row count / current page and the rows per page displays.
In the screenshot below the tooltip is positioned to the right of the row count display:
<img width="1007" alt="image" src="https://github.com/avaya-dux/neo-react-library/assets/3535271/e2819c92-580f-4c81-9275-48b4f3248585">
<img width="1007" alt="image" src="https://github.com/avaya-dux/neo-react-library/assets/3535271/e2819c92-580f-4c81-9275-48b4f3248585">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for table captions.
  - Introduced tooltip positioning for item display and items per page in tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->