### PR TITLE
vertically center notification text when there is only the title or description 

### DIFF
--- a/src/components/Notification/notification_shim.css
+++ b/src/components/Notification/notification_shim.css
@@ -217,7 +217,3 @@ div.neo-notification__description {
   display: flex;
 	align-items: center;
 }
-
-.neo-notification .neo-notification__message {
-	justify-content: unset;
-}


### PR DESCRIPTION
[Link to updated Notifications stories](https://deploy-preview-409--neo-react-library-storybook.netlify.app/?path=/story/components-notification--content-variants)

**Before tagging the team for a review, I have done the following:**
- [x] reviewed my code changes
- [x] ensured that all tests pass
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged Matt if any visual changes have occurred
- [x] done an accessibility check on my work

@avaya-dux/dux-design: this 👇  is what [you are asking for](https://github.com/avaya-dux/neo-react-library/pull/407#issuecomment-2140943027) yes?

![Screenshot 2024-05-31 at 09 17 44](https://github.com/avaya-dux/neo-react-library/assets/55896546/66144085-bd50-4eea-93b8-b874d2e70094)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout and alignment of notification messages by updating the notification styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->