### PR TITLE
make biome more strict

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,6 +3,10 @@
 {
 	"linter": {
 		"rules": {
+			"correctness": {
+				"noUnusedVariables": "error",
+				"noUnusedImports": "error"
+			},
 			"complexity": {
 				"noForEach": "off"
 			},

--- a/src/components/LeftNav/LeftNav.stories.tsx
+++ b/src/components/LeftNav/LeftNav.stories.tsx
@@ -7,7 +7,7 @@ export default {
 	component: LeftNav,
 } as Meta<LeftNavProps>;
 
-const handleClick = (id: string, url: string) => {
+const handleClick = (_id: string, url: string) => {
 	window.open(url);
 };
 


### PR DESCRIPTION
@avaya-dux/dux-devs I noticed that the linting isn't as strict as I'd like it to be (it previously allowed unused variables and imports). This update makes those not allowed. 

The first run of this should fail in our CI pipeline. If it fails appropriately, I'll make the requested update, wait for it to pass, and then merge. 

EDIT: [first run failed appropriately](https://github.com/avaya-dux/neo-react-library/actions/runs/9389319755/job/25856535907?pr=415) 💯 🥳 