### PR TITLE
NEO-2146 allow collapse of chips in multi select

### DIFF
--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, Story } from "@storybook/react";
 
+import { useEffect, useRef, useState } from "react";
 import { Chip, type ChipProps, ChipsContainer } from "./";
 
 export default {
@@ -20,6 +21,49 @@ export const Closable = () => (
 		</Chip>
 	</ChipsContainer>
 );
+
+export const WithRef = () => {
+	const chipRef = useRef<HTMLDivElement>(null);
+
+	const [chipWidth, setChipWidth] = useState(0);
+
+	useEffect(() => {
+		if (chipRef.current) {
+			setChipWidth(chipRef.current.offsetWidth);
+		}
+	}, []);
+
+	return (
+		<ChipsContainer>
+			<Chip ref={chipRef}>With Ref</Chip>
+			<div>Chip Width: {chipWidth}px</div>
+		</ChipsContainer>
+	);
+};
+
+export const WithRefArray = () => {
+	const chipRefs = useRef<HTMLDivElement[]>([]);
+	const [chipWidth, setChipWidth] = useState(0);
+
+	useEffect(() => {
+		if (chipRefs.current[0]) {
+			setChipWidth(chipRefs.current[0].offsetWidth);
+		}
+	}, []);
+
+	const setChipRef = (el: HTMLDivElement | null, index: number) => {
+		if (el) {
+			chipRefs.current[index] = el;
+		}
+	};
+
+	return (
+		<ChipsContainer>
+			<Chip ref={(el) => setChipRef(el, 0)}>With Ref Array</Chip>
+			<div>Chip Width: {chipWidth}px</div>
+		</ChipsContainer>
+	);
+};
 
 export const ChipsContainerExamples = () => (
 	<div>

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -22,7 +22,7 @@ export const Closable = () => (
 	</ChipsContainer>
 );
 
-export const WithRef = () => {
+export const GetWidth = () => {
 	const chipRef = useRef<HTMLDivElement>(null);
 
 	const [chipWidth, setChipWidth] = useState(0);
@@ -34,23 +34,25 @@ export const WithRef = () => {
 	}, []);
 
 	return (
-		<ChipsContainer>
-			<Chip ref={chipRef} onClick={() => console.log("clicked")}>
-				With Ref
-			</Chip>
-			<div>Chip Width: {chipWidth}px</div>
-		</ChipsContainer>
+		<section>
+			<p>This example shows how to get width of a Chip using a ref.</p>
+			<ChipsContainer>
+				<Chip ref={chipRef} onClick={() => console.log("clicked")}>
+					Chip to measure
+				</Chip>
+				<div>Width in px: {chipWidth}</div>
+			</ChipsContainer>
+		</section>
 	);
 };
 
-export const WithRefArray = () => {
+export const GetWidths = () => {
 	const chipRefs = useRef<HTMLDivElement[]>([]);
-	const [chipWidth, setChipWidth] = useState(0);
+	const [chipWidths, setChipWidths] = useState<number[]>([]);
 
 	useEffect(() => {
-		if (chipRefs.current[0]) {
-			setChipWidth(chipRefs.current[0].offsetWidth);
-		}
+		const widths = chipRefs.current.map((chip) => chip.offsetWidth);
+		setChipWidths(widths);
 	}, []);
 
 	const setChipRef = (el: HTMLDivElement | null, index: number) => {
@@ -60,10 +62,16 @@ export const WithRefArray = () => {
 	};
 
 	return (
-		<ChipsContainer>
-			<Chip ref={(el) => setChipRef(el, 0)}>With Ref Array</Chip>
-			<div>Chip Width: {chipWidth}px</div>
-		</ChipsContainer>
+		<section>
+			<p>
+				This example shows how to get width of Chips using an array of refs.
+			</p>
+			<ChipsContainer>
+				<Chip ref={(el) => setChipRef(el, 0)}>Chip 1</Chip>
+				<Chip ref={(el) => setChipRef(el, 1)}>Chip 2</Chip>
+				<div>Widths in px: {JSON.stringify(chipWidths)}</div>
+			</ChipsContainer>
+		</section>
 	);
 };
 

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -35,7 +35,9 @@ export const WithRef = () => {
 
 	return (
 		<ChipsContainer>
-			<Chip ref={chipRef}>With Ref</Chip>
+			<Chip ref={chipRef} onClick={() => console.log("clicked")}>
+				With Ref
+			</Chip>
 			<div>Chip Width: {chipWidth}px</div>
 		</ChipsContainer>
 	);

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -4,7 +4,7 @@ import { axe } from "jest-axe";
 import { vi } from "vitest";
 
 import { Chip } from "./";
-import { Closable, Default, Templated } from "./Chip.stories";
+import { Closable, Default, Templated, WithRef, WithRefArray } from "./Chip.stories";
 
 describe("Chip", () => {
 	const user = userEvent.setup();
@@ -113,6 +113,44 @@ describe("Chip", () => {
 
 			beforeEach(() => {
 				renderResult = render(<Templated>test</Templated>);
+			});
+
+			it("should render ok", () => {
+				const { container } = renderResult;
+				expect(container).not.toBe(null);
+			});
+
+			it("passes basic axe compliance", async () => {
+				const { container } = renderResult;
+				const results = await axe(container);
+				expect(results).toHaveNoViolations();
+			});
+		});
+
+		describe("WithRef", () => {
+			let renderResult: RenderResult;
+
+			beforeEach(() => {
+				renderResult = render(<WithRef />);
+			});
+
+			it("should render ok", () => {
+				const { container } = renderResult;
+				expect(container).not.toBe(null);
+			});
+
+			it("passes basic axe compliance", async () => {
+				const { container } = renderResult;
+				const results = await axe(container);
+				expect(results).toHaveNoViolations();
+			});
+		});
+
+		describe("WithRefArray", () => {
+			let renderResult: RenderResult;
+
+			beforeEach(() => {
+				renderResult = render(<WithRefArray />);
 			});
 
 			it("should render ok", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -7,9 +7,9 @@ import { Chip } from "./";
 import {
 	Closable,
 	Default,
+	GetWidth,
+	GetWidths,
 	Templated,
-	WithRef,
-	WithRefArray,
 } from "./Chip.stories";
 
 describe("Chip", () => {
@@ -133,11 +133,11 @@ describe("Chip", () => {
 			});
 		});
 
-		describe("WithRef", () => {
+		describe("GetWidth", () => {
 			let renderResult: RenderResult;
 
 			beforeEach(() => {
-				renderResult = render(<WithRef />);
+				renderResult = render(<GetWidth />);
 			});
 
 			it("should render ok", () => {
@@ -152,11 +152,11 @@ describe("Chip", () => {
 			});
 		});
 
-		describe("WithRefArray", () => {
+		describe("GetWidths", () => {
 			let renderResult: RenderResult;
 
 			beforeEach(() => {
-				renderResult = render(<WithRefArray />);
+				renderResult = render(<GetWidths />);
 			});
 
 			it("should render ok", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -4,7 +4,13 @@ import { axe } from "jest-axe";
 import { vi } from "vitest";
 
 import { Chip } from "./";
-import { Closable, Default, Templated, WithRef, WithRefArray } from "./Chip.stories";
+import {
+	Closable,
+	Default,
+	Templated,
+	WithRef,
+	WithRefArray,
+} from "./Chip.stories";
 
 describe("Chip", () => {
 	const user = userEvent.setup();

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,5 +1,10 @@
 import clsx from "clsx";
-import { type HTMLAttributes, type MouseEventHandler, useState } from "react";
+import {
+	type HTMLAttributes,
+	type MouseEventHandler,
+	forwardRef,
+	useState,
+} from "react";
 
 import { Avatar } from "components/Avatar";
 import type { IconNamesType } from "utils";
@@ -28,57 +33,63 @@ export interface ChipProps
  * @see https://design.avayacloud.com/components/web/chip-web
  * @see https://neo-react-library-storybook.netlify.app/?path=/story/components-chips
  */
-export const Chip = ({
-	avatarInitials,
-	children,
-	className,
-	closable = false,
-	closeButtonAriaLabel = "Close",
-	disabled = false,
-	icon,
-	onClose,
-	variant = "default",
-	...rest
-}: ChipProps) => {
-	const [closed, setClosed] = useState(false);
+export const Chip = forwardRef<HTMLDivElement, ChipProps>(
+	(
+		{
+			avatarInitials,
+			children,
+			className,
+			closable = false,
+			closeButtonAriaLabel = "Close",
+			disabled = false,
+			icon,
+			onClose,
+			variant = "default",
+			...rest
+		},
+		ref,
+	) => {
+		const [closed, setClosed] = useState(false);
 
-	if (avatarInitials && icon) {
-		throw new Error(
-			"Chip cannot have both an Avatar and an Icon, it must have one or the other.",
+		if (avatarInitials && icon) {
+			throw new Error(
+				"Chip cannot have both an Avatar and an Icon, it must have one or the other.",
+			);
+		}
+
+		return closed ? (
+			<></>
+		) : (
+			<div
+				ref={ref}
+				className={clsx(
+					`neo-chip neo-chip--${variant}`,
+					disabled && `neo-chip--${variant}--disabled`,
+					icon && `neo-icon-${icon}`,
+					closable && `neo-chip--close neo-chip--close--${variant}`,
+					className,
+				)}
+				{...rest}
+			>
+				{avatarInitials && <Avatar initials={avatarInitials} size="sm" />}
+				{children}
+				{closable && (
+					<button
+						type="button"
+						className="neo-close neo-close--clear"
+						aria-label={closeButtonAriaLabel}
+						// TO-DO: NEO-1549: Add the below styling rule in the CSS library
+						style={{ pointerEvents: disabled ? "none" : "initial" }}
+						disabled={disabled}
+						onClick={(e) => {
+							setClosed(true);
+							onClose?.(e);
+						}}
+					/>
+				)}
+			</div>
 		);
-	}
-
-	return closed ? (
-		<></>
-	) : (
-		<div
-			className={clsx(
-				`neo-chip neo-chip--${variant}`,
-				disabled && `neo-chip--${variant}--disabled`,
-				icon && `neo-icon-${icon}`,
-				closable && `neo-chip--close neo-chip--close--${variant}`,
-				className,
-			)}
-			{...rest}
-		>
-			{avatarInitials && <Avatar initials={avatarInitials} size="sm" />}
-			{children}
-			{closable && (
-				<button
-					type="button"
-					className="neo-close neo-close--clear"
-					aria-label={closeButtonAriaLabel}
-					// TO-DO: NEO-1549: Add the below styling rule in the CSS library
-					style={{ pointerEvents: disabled ? "none" : "initial" }}
-					disabled={disabled}
-					onClick={(e) => {
-						setClosed(true);
-						onClose?.(e);
-					}}
-				/>
-			)}
-		</div>
-	);
-};
+	},
+);
 
 Chip.displayName = "Chip";

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -20,7 +20,7 @@ import { Tooltip } from "components/Tooltip";
 import log from "loglevel";
 import { reactNodeToString } from "utils";
 const logger = log.getLogger("multiselect-logger");
-logger.enableAll();
+logger.disableAll();
 
 export const MultiSelect = () => {
 	const {

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -96,13 +96,8 @@ export const MultiSelect = () => {
 		const chipContents: string[] = chipRefs.current.map(
 			(ref) => ref.textContent || "",
 		);
-		// 120px is the room reserved for the badge chip, the 2 buttons and some padding
-		const reservedSpace = 120;
-		const result = calculateWidthsUntilExceed(
-			containerWidth,
-			widths,
-			reservedSpace,
-		);
+
+		const result = calculateWidthsUntilExceed(containerWidth, widths);
 		logger.debug(
 			`4.2 result ${JSON.stringify({ result, widths, containerWidth, chipContents })}`,
 		);

--- a/src/components/Select/Select.cy.tsx
+++ b/src/components/Select/Select.cy.tsx
@@ -9,7 +9,7 @@ describe("Single Select Chevron tests", () => {
 		cy.mount(<BasicSelects />);
 
 		cy.get("span button")
-			.first()	// open the select
+			.first() // open the select
 			.then(($element) => {
 				const width = $element.width();
 				const height = $element.height();

--- a/src/components/Select/Select.cy.tsx
+++ b/src/components/Select/Select.cy.tsx
@@ -1,11 +1,15 @@
-import { BasicSelects, Searchable } from "./Select.stories";
+import {
+	BasicSelects,
+	CollapsedMultiSelect,
+	Searchable,
+} from "./Select.stories";
 
 describe("Single Select Chevron tests", () => {
 	it("Clicking on Chevron should make first menu item visible", () => {
 		cy.mount(<BasicSelects />);
 
 		cy.get("span button")
-			.first()
+			.first()	// open the select
 			.then(($element) => {
 				const width = $element.width();
 				const height = $element.height();
@@ -29,7 +33,7 @@ describe("Single Select Scrolling Tests", () => {
 	it("Last fruit in the list becomes visible with arrow downs", () => {
 		cy.mount(<BasicSelects />);
 
-		cy.get("span button").first().click(); // click the first select one
+		cy.get("span button").first().click(); // open the select
 
 		cy.get("[role='listbox']")
 			.first()
@@ -72,5 +76,34 @@ describe("Single Select Searchable Scrolling Tests", () => {
 			.within(() => {
 				cy.get("ul li").last().should("be.visible");
 			});
+	});
+});
+
+describe("Multi Select Scrolling Tests", () => {
+	it("Select apple, broccoli, pear, banana and the chip should show +2 on it", () => {
+		cy.mount(<CollapsedMultiSelect />);
+
+		// open the select
+		cy.get("span button").first().click();
+		// select option apple
+		cy.get("[role='listbox']").first().contains("li", "Apple").first().click();
+		// select option broccoli
+		cy.get("[role='listbox']")
+			.first()
+			.contains("li", "Broccoli")
+			.first()
+			.click();
+		// select option pear
+		cy.get("[role='listbox']").first().contains("li", "Pear").first().click();
+		// select option banana
+		cy.get("[role='listbox']").first().contains("li", "Banana").first().click();
+		// select chips and assert there are 3 chips
+		cy.get(".neo-chip.neo-chip--default").should("have.length", 3);
+		// select the collapsed chip
+		const collapsedChip = cy.get(".neo-chip.neo-chip--default").contains("+2");
+		// assert collapsedChip is visible
+		collapsedChip.should("be.visible");
+		// assert collapsedChip has aria-describedby attribute with non-empty value
+		collapsedChip.should("have.attr", "aria-describedby").and("not.be.empty");
 	});
 });

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -74,6 +74,33 @@ export const BasicSelects = () => {
 	);
 };
 
+export const CollapsedMultiSelect = () => {
+	const [foods, setFoods] = useState<string[]>([]);
+
+	return (
+		<Sheet title="Multi Select that collapses chips" style={{ width: 400 }}>
+			<Select
+				helperText="Please select one or more"
+				label="Select a few nice foods"
+				multiple
+				collapse
+				onChange={(value) => setFoods(value as string[])}
+			>
+				{fruitOptions}
+			</Select>
+			<div>
+				<p>Nice Foods Selection: {foods.length === 0 && "None Selected"}</p>
+
+				<ul>
+					{foods.map((food) => (
+						<li key={food}>{food}</li>
+					))}
+				</ul>
+			</div>
+		</Sheet>
+	);
+};
+
 export const Localized = () => {
 	const [lang, setLang] = useState("English");
 	const [currTranslations, setCurrTranslations] = useState(englishTrans);

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -78,7 +78,7 @@ export const CollapsedMultiSelect = () => {
 	const [foods, setFoods] = useState<string[]>([]);
 
 	return (
-		<Sheet title="Multi Select that collapses chips" style={{ width: 400 }}>
+		<Sheet title="Multi Select (Collapse)" style={{ width: 400 }}>
 			<Select
 				helperText="Please select one or more"
 				label="Select a few nice foods"
@@ -101,6 +101,32 @@ export const CollapsedMultiSelect = () => {
 	);
 };
 
+export const CollapsedNarrowMultiSelect = () => {
+	const [foods, setFoods] = useState<string[]>([]);
+
+	return (
+		<Sheet title="Narrow Multi Select (Collapse)" style={{ width: 250 }}>
+			<Select
+				helperText="Please select one or more"
+				label="Select a few nice foods"
+				multiple
+				collapse
+				onChange={(value) => setFoods(value as string[])}
+			>
+				{fruitOptions}
+			</Select>
+			<div>
+				<p>Nice Foods Selection: {foods.length === 0 && "None Selected"}</p>
+
+				<ul>
+					{foods.map((food) => (
+						<li key={food}>{food}</li>
+					))}
+				</ul>
+			</div>
+		</Sheet>
+	);
+};
 export const Localized = () => {
 	const [lang, setLang] = useState("English");
 	const [currTranslations, setCurrTranslations] = useState(englishTrans);

--- a/src/components/Select/Select.test.jsx
+++ b/src/components/Select/Select.test.jsx
@@ -17,6 +17,7 @@ logger.disableAll();
 
 const {
 	BasicSelects,
+	CollapsedMultiSelect,
 	Searchable,
 	Disabled,
 	DefaultValues,
@@ -348,6 +349,19 @@ describe("Select", () => {
 				disabledListItems.forEach((disabledListItem) => {
 					expect(disabledListItem).toHaveAttribute("disabled");
 				});
+			});
+
+			it("passes basic axe compliance", async () => {
+				const { container } = renderResult;
+				const results = await axe(container);
+				expect(results).toHaveNoViolations();
+			});
+		});
+
+		describe("Collapsed Multi Select", () => {
+			let renderResult;
+			beforeEach(() => {
+				renderResult = render(<CollapsedMultiSelect />);
 			});
 
 			it("passes basic axe compliance", async () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -69,6 +69,7 @@ export const Select = (props: SelectProps) => {
 		placeholder = "",
 		required,
 		searchable = false,
+		collapse = false,
 		value,
 		size = "md",
 		style,
@@ -198,6 +199,7 @@ export const Select = (props: SelectProps) => {
 		},
 		optionProps: {
 			multiple,
+			collapse,
 			noOptionsMessage,
 			options,
 			selectedItems,

--- a/src/components/Select/utils/SelectContext.tsx
+++ b/src/components/Select/utils/SelectContext.tsx
@@ -25,6 +25,7 @@ export type SelectContextProps = {
 
 	optionProps: {
 		multiple: boolean;
+		collapse: boolean;
 		noOptionsMessage: string;
 		options: SelectOptionProps[];
 		selectedItems: SelectOptionProps[];
@@ -46,6 +47,7 @@ export const SelectContext = createContext<SelectContextProps>({
 
 	optionProps: {
 		multiple: false,
+		collapse: false,
 		noOptionsMessage: "",
 		options: [],
 		selectedItems: [],

--- a/src/components/Select/utils/SelectTypes.tsx
+++ b/src/components/Select/utils/SelectTypes.tsx
@@ -34,6 +34,7 @@ export type SelectProps = {
 	placeholder?: string;
 	required?: boolean;
 	searchable?: boolean;
+	collapse?: boolean;
 	value?: string | string[];
 	size?: SizeTypeSelect;
 	style?: React.CSSProperties;

--- a/src/components/Select/utils/multiSelectHelper.test.jsx
+++ b/src/components/Select/utils/multiSelectHelper.test.jsx
@@ -5,7 +5,7 @@ describe("calculateWidthsUntilExceed", () => {
 		const containerWidth = 100;
 		const widths = [];
 		const expected = { totalWidth: 0, index: -1, hiddenCount: 0 };
-		expect(calculateWidthsUntilExceed(containerWidth, widths)).toEqual(
+		expect(calculateWidthsUntilExceed(containerWidth, widths, 50)).toEqual(
 			expected,
 		);
 	});

--- a/src/components/Select/utils/multiSelectHelper.test.jsx
+++ b/src/components/Select/utils/multiSelectHelper.test.jsx
@@ -1,0 +1,48 @@
+import { calculateWidthsUntilExceed } from "./multiSelectHelper";
+
+describe("calculateWidthsUntilExceed", () => {
+	it("should return initial values when widths array is empty", () => {
+		const containerWidth = 100;
+		const widths = [];
+		const expected = { totalWidth: 0, index: -1, hiddenCount: 0 };
+		expect(calculateWidthsUntilExceed(containerWidth, widths)).toEqual(
+			expected,
+		);
+	});
+
+	it("should calculate totalWidth and index correctly without exceeding containerWidth", () => {
+		const containerWidth = 150;
+		const widths = [50, 50, 50]; // Total = 150, exactly the container width
+		const expected = { totalWidth: 150, index: 2, hiddenCount: 0 };
+		expect(calculateWidthsUntilExceed(containerWidth, widths, 0)).toEqual(
+			expected,
+		);
+	});
+
+	it("should stop adding widths when exceeding containerWidth and count hidden elements", () => {
+		const containerWidth = 100;
+		const widths = [30, 30, 30, 30]; // Exceeds at the last element
+		const expected = { totalWidth: 60, index: 1, hiddenCount: 2 }; // Last one is hidden
+		expect(calculateWidthsUntilExceed(containerWidth, widths, 30)).toEqual(
+			expected,
+		);
+	});
+
+	it("should handle single element arrays correctly", () => {
+		const containerWidth = 50;
+		const widths = [60]; // Single element exceeding container width
+		const expected = { totalWidth: 0, index: -1, hiddenCount: 1 }; // One hidden, none shown
+		expect(calculateWidthsUntilExceed(containerWidth, widths, 0)).toEqual(
+			expected,
+		);
+	});
+
+	it("should return all widths as visible if total does not exceed containerWidth", () => {
+		const containerWidth = 200;
+		const widths = [40, 40, 40, 40]; // Total = 160, under the container width
+		const expected = { totalWidth: 160, index: 3, hiddenCount: 0 }; // All visible
+		expect(calculateWidthsUntilExceed(containerWidth, widths, 20)).toEqual(
+			expected,
+		);
+	});
+});

--- a/src/components/Select/utils/multiSelectHelper.test.jsx
+++ b/src/components/Select/utils/multiSelectHelper.test.jsx
@@ -1,48 +1,46 @@
-import { calculateWidthsUntilExceed } from "./multiSelectHelper";
+import { calculateVisibleChips } from "./multiSelectHelper";
 
-describe("calculateWidthsUntilExceed", () => {
+describe("calculateVisibleChips", () => {
 	it("should return initial values when widths array is empty", () => {
 		const containerWidth = 100;
 		const widths = [];
-		const expected = { totalWidth: 0, index: -1, hiddenCount: 0 };
-		expect(calculateWidthsUntilExceed(containerWidth, widths, 50)).toEqual(
-			expected,
-		);
+		const expected = { totalVisibleWidth: 0, lastVisibleIndex: -1, collapsedCount: 0 };
+		expect(calculateVisibleChips(containerWidth, widths, 50)).toEqual(expected);
 	});
 
-	it("should calculate totalWidth and index correctly without exceeding containerWidth", () => {
+	it("should calculate totalVisibleWidth and lastVisibleIndex correctly without exceeding containerWidth", () => {
 		const containerWidth = 150;
 		const widths = [50, 50, 50]; // exactly the container width
-		const expected = { totalWidth: 150, index: 2, hiddenCount: 0 };
-		expect(calculateWidthsUntilExceed(containerWidth, widths, 0)).toEqual(
-			expected,
-		);
+		const expected = {
+			totalVisibleWidth: 150,
+			lastVisibleIndex: 2,
+			collapsedCount: 0,
+		};
+		expect(calculateVisibleChips(containerWidth, widths, 0)).toEqual(expected);
 	});
 
 	it("should stop adding widths when exceeding containerWidth and count hidden elements", () => {
 		const containerWidth = 100;
 		const widths = [30, 30, 30, 30];
-		const expected = { totalWidth: 60, index: 1, hiddenCount: 2 };
-		expect(calculateWidthsUntilExceed(containerWidth, widths, 30)).toEqual(
-			expected,
-		);
+		const expected = { totalVisibleWidth: 60, lastVisibleIndex: 1, collapsedCount: 2 };
+		expect(calculateVisibleChips(containerWidth, widths, 30)).toEqual(expected);
 	});
 
 	it("should handle single element arrays correctly", () => {
 		const containerWidth = 50;
 		const widths = [60]; // Single element exceeding container width
-		const expected = { totalWidth: 0, index: -1, hiddenCount: 1 }; // One hidden, none shown
-		expect(calculateWidthsUntilExceed(containerWidth, widths, 0)).toEqual(
-			expected,
-		);
+		const expected = { totalVisibleWidth: 0, lastVisibleIndex: -1, collapsedCount: 1 }; // One hidden, none shown
+		expect(calculateVisibleChips(containerWidth, widths, 0)).toEqual(expected);
 	});
 
 	it("should return all widths as visible if total does not exceed containerWidth", () => {
 		const containerWidth = 200;
 		const widths = [40, 40, 40, 40]; // Total = 160, less than containerWidth
-		const expected = { totalWidth: 160, index: 3, hiddenCount: 0 }; // All visible
-		expect(calculateWidthsUntilExceed(containerWidth, widths, 20)).toEqual(
-			expected,
-		);
+		const expected = {
+			totalVisibleWidth: 160,
+			lastVisibleIndex: 3,
+			collapsedCount: 0,
+		}; // All visible
+		expect(calculateVisibleChips(containerWidth, widths, 20)).toEqual(expected);
 	});
 });

--- a/src/components/Select/utils/multiSelectHelper.test.jsx
+++ b/src/components/Select/utils/multiSelectHelper.test.jsx
@@ -12,7 +12,7 @@ describe("calculateWidthsUntilExceed", () => {
 
 	it("should calculate totalWidth and index correctly without exceeding containerWidth", () => {
 		const containerWidth = 150;
-		const widths = [50, 50, 50]; // Total = 150, exactly the container width
+		const widths = [50, 50, 50]; // exactly the container width
 		const expected = { totalWidth: 150, index: 2, hiddenCount: 0 };
 		expect(calculateWidthsUntilExceed(containerWidth, widths, 0)).toEqual(
 			expected,
@@ -21,8 +21,8 @@ describe("calculateWidthsUntilExceed", () => {
 
 	it("should stop adding widths when exceeding containerWidth and count hidden elements", () => {
 		const containerWidth = 100;
-		const widths = [30, 30, 30, 30]; // Exceeds at the last element
-		const expected = { totalWidth: 60, index: 1, hiddenCount: 2 }; // Last one is hidden
+		const widths = [30, 30, 30, 30];
+		const expected = { totalWidth: 60, index: 1, hiddenCount: 2 };
 		expect(calculateWidthsUntilExceed(containerWidth, widths, 30)).toEqual(
 			expected,
 		);
@@ -39,7 +39,7 @@ describe("calculateWidthsUntilExceed", () => {
 
 	it("should return all widths as visible if total does not exceed containerWidth", () => {
 		const containerWidth = 200;
-		const widths = [40, 40, 40, 40]; // Total = 160, under the container width
+		const widths = [40, 40, 40, 40]; // Total = 160, less than containerWidth
 		const expected = { totalWidth: 160, index: 3, hiddenCount: 0 }; // All visible
 		expect(calculateWidthsUntilExceed(containerWidth, widths, 20)).toEqual(
 			expected,

--- a/src/components/Select/utils/multiSelectHelper.test.jsx
+++ b/src/components/Select/utils/multiSelectHelper.test.jsx
@@ -4,7 +4,11 @@ describe("calculateVisibleChips", () => {
 	it("should return initial values when widths array is empty", () => {
 		const containerWidth = 100;
 		const widths = [];
-		const expected = { totalVisibleWidth: 0, lastVisibleIndex: -1, collapsedCount: 0 };
+		const expected = {
+			totalVisibleWidth: 0,
+			lastVisibleIndex: -1,
+			collapsedCount: 0,
+		};
 		expect(calculateVisibleChips(containerWidth, widths, 50)).toEqual(expected);
 	});
 
@@ -22,14 +26,22 @@ describe("calculateVisibleChips", () => {
 	it("should stop adding widths when exceeding containerWidth and count hidden elements", () => {
 		const containerWidth = 100;
 		const widths = [30, 30, 30, 30];
-		const expected = { totalVisibleWidth: 60, lastVisibleIndex: 1, collapsedCount: 2 };
+		const expected = {
+			totalVisibleWidth: 60,
+			lastVisibleIndex: 1,
+			collapsedCount: 2,
+		};
 		expect(calculateVisibleChips(containerWidth, widths, 30)).toEqual(expected);
 	});
 
 	it("should handle single element arrays correctly", () => {
 		const containerWidth = 50;
 		const widths = [60]; // Single element exceeding container width
-		const expected = { totalVisibleWidth: 0, lastVisibleIndex: -1, collapsedCount: 1 }; // One hidden, none shown
+		const expected = {
+			totalVisibleWidth: 0,
+			lastVisibleIndex: -1,
+			collapsedCount: 1,
+		}; // One hidden, none shown
 		expect(calculateVisibleChips(containerWidth, widths, 0)).toEqual(expected);
 	});
 

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -2,7 +2,8 @@ import log from "loglevel";
 const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
-const MIN_CHIP_WIDTH = 50; // Minimum width of a chip
+// 120px is the room reserved for the badge chip, the 2 buttons and some padding
+const MIN_CHIP_WIDTH = 120;
 export function calculateWidthsUntilExceed(
 	containerWidth: number,
 	widths: number[],
@@ -22,8 +23,8 @@ export function calculateWidthsUntilExceed(
 			break;
 		}
 
-		totalWidth += width; // Update total width
-		index = i; // Update index
+		totalWidth += width;
+		index = i;
 		logger.debug(`not exceeding: {totalWidth: ${totalWidth}, index: ${index}}`);
 	}
 

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -2,7 +2,7 @@ import log from "loglevel";
 const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
-// 120px is the room reserved for the badge chip, the 2 buttons and some padding
+// 120px is the space reserved for the badge chip, the 2 buttons and some padding
 const MIN_CHIP_WIDTH = 120;
 export function calculateWidthsUntilExceed(
 	containerWidth: number,
@@ -11,12 +11,14 @@ export function calculateWidthsUntilExceed(
 ) {
 	let totalWidth = 0;
 	let index = -1;
-
+	logger.debug(
+		`calculateWidthsUntilExceed 1: {containerWidth: ${containerWidth}, widths: ${JSON.stringify(widths)}, minChipWidth: ${minChipWidth}}`,
+	);
 	for (let i = 0; i < widths.length; i++) {
 		const width = widths[i];
 		const exceeds = totalWidth + width > containerWidth - minChipWidth;
 		logger.debug(
-			`{totalWidth: ${totalWidth}, index: ${index}, i=${i}, width=${width}, exceeds=${exceeds}`,
+			`calculateWidthsUntilExceed 2: {totalWidth: ${totalWidth}, index: ${index}, i=${i}, width=${width}, exceeds=${exceeds}`,
 		);
 
 		if (exceeds) {
@@ -25,7 +27,9 @@ export function calculateWidthsUntilExceed(
 
 		totalWidth += width;
 		index = i;
-		logger.debug(`not exceeding: {totalWidth: ${totalWidth}, index: ${index}}`);
+		logger.debug(
+			`calculateWidthsUntilExceed 2.1: not exceeding: {totalWidth: ${totalWidth}, index: ${index}}`,
+		);
 	}
 
 	const result = {
@@ -34,6 +38,6 @@ export function calculateWidthsUntilExceed(
 		hiddenCount: widths.length - index - 1,
 	};
 
-	logger.debug(`calculateWidthsUntilExceed returns ${JSON.stringify(result)}`);
+	logger.debug(`calculateWidthsUntilExceed 3: ${JSON.stringify(result)}`);
 	return result;
 }

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -3,41 +3,48 @@ const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
 // 120px is the space reserved for the badge chip, the 2 buttons and some padding
-const MIN_CHIP_WIDTH = 120;
-export function calculateWidthsUntilExceed(
+const MIN_RESERVED_SPACE = 120;
+/**
+ * Calculate the number of chips that can be displayed in the container
+ * @param {number} containerWidth - The width of the container.
+ * @param {number[]} chipWidths - Array containing the widths of chips of selected items.
+ * @param {number} [reservedSpace=MIN_RESERVED_SPACE] - Space reserved for the badge chip that shows the number of collapsed items.
+ * @returns {{totalVisibleWidth: number, lastVisibleIndex: number, collapsedCount: number}} An object containing the total width of visible chips, the index of the last visible chip, and the count of collapsed chips.
+ */
+export function calculateVisibleChips(
 	containerWidth: number,
-	widths: number[],
-	minChipWidth: number = MIN_CHIP_WIDTH,
+	chipWidths: number[],
+	reservedSpace: number = MIN_RESERVED_SPACE,
 ) {
-	let totalWidth = 0;
+	let totalVisibleWidth = 0;
 	let index = -1;
 	logger.debug(
-		`calculateWidthsUntilExceed 1: {containerWidth: ${containerWidth}, widths: ${JSON.stringify(widths)}, minChipWidth: ${minChipWidth}}`,
+		`calculateVisibleChips 1: {containerWidth: ${containerWidth}, chipWidths: ${JSON.stringify(chipWidths)}, reservedSpace: ${reservedSpace}}`,
 	);
-	for (let i = 0; i < widths.length; i++) {
-		const width = widths[i];
-		const exceeds = totalWidth + width > containerWidth - minChipWidth;
+	for (let i = 0; i < chipWidths.length; i++) {
+		const width = chipWidths[i];
+		const exceeds = totalVisibleWidth + width > containerWidth - reservedSpace;
 		logger.debug(
-			`calculateWidthsUntilExceed 2: {totalWidth: ${totalWidth}, index: ${index}, i=${i}, width=${width}, exceeds=${exceeds}`,
+			`calculateVisibleChips 2: {totalVisibleWidth: ${totalVisibleWidth}, index: ${index}, i=${i}, width=${width}, exceeds=${exceeds}`,
 		);
 
 		if (exceeds) {
 			break;
 		}
 
-		totalWidth += width;
+		totalVisibleWidth += width;
 		index = i;
 		logger.debug(
-			`calculateWidthsUntilExceed 2.1: not exceeding: {totalWidth: ${totalWidth}, index: ${index}}`,
+			`calculateVisibleChips 2.1: not exceeding: {totalVisibleWidth: ${totalVisibleWidth}, index: ${index}}`,
 		);
 	}
 
 	const result = {
-		totalWidth,
-		index,
-		hiddenCount: widths.length - index - 1,
+		totalVisibleWidth,
+		lastVisibleIndex: index,
+		collapsedCount: chipWidths.length - index - 1,
 	};
 
-	logger.debug(`calculateWidthsUntilExceed 3: ${JSON.stringify(result)}`);
+	logger.debug(`calculateVisibleChips 3: ${JSON.stringify(result)}`);
 	return result;
 }

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -1,0 +1,38 @@
+import log from "loglevel";
+const logger = log.getLogger("multiselect-helper-logger");
+logger.disableAll();
+
+const MIN_CHIP_WIDTH = 50; // Minimum width of a chip
+export function calculateWidthsUntilExceed(
+	containerWidth: number,
+	widths: number[],
+	minChipWidth: number = MIN_CHIP_WIDTH,
+) {
+	let totalWidth = 0;
+	let index = -1;
+
+	for (let i = 0; i < widths.length; i++) {
+		const width = widths[i];
+		const exceeds = totalWidth + width > containerWidth - minChipWidth;
+		logger.debug(
+			`{totalWidth: ${totalWidth}, index: ${index}, i=${i}, width=${width}, exceeds=${exceeds}`,
+		);
+
+		if (exceeds) {
+			break;
+		}
+
+		totalWidth += width; // Update total width
+		index = i; // Update index
+		logger.debug(`not exceeding: {totalWidth: ${totalWidth}, index: ${index}}`);
+	}
+
+	const result = {
+		totalWidth,
+		index,
+		hiddenCount: widths.length - index - 1,
+	};
+
+	logger.debug(`calculateWidthsUntilExceed returns ${JSON.stringify(result)}`);
+	return result;
+}


### PR DESCRIPTION
[Story #1](https://deploy-preview-427--neo-react-library-storybook.netlify.app/?path=/story/components-select--collapsed-multi-select)
[Story #2](https://deploy-preview-427--neo-react-library-storybook.netlify.app/?path=/story/components-select--collapsed-narrow-multi-select)


**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY (should be brief, one sentence if possible)

`@avaya-dux/dux-design`: ADD DESIGN SPECIFIC BRIEF DESCRIPTION
- followed the design portal Select page on collapse chips
- did not implement click on chip per discussion
- 2 stories to check under Select

`@avaya-dux/dux-devs`: ADD DEV SPECIFIC BRIEF DESCRIPTION

- changed Chip to allow forward ref
- added collapse prop to Select
- only MultiSelect supports collapse in this PR per requested by external team



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved MultiSelect component with enhanced chip rendering and visibility calculations.
	- Introduced logging for better monitoring of chip rendering stages.
- **Tests**
	- Added test suites to validate calculations of chip widths and visibility within containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->