### PR TITLE
WIP: don't allow index to go negative

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -373,6 +373,12 @@ export const EditableData = () => {
 				data={data}
 				readonly={readonly}
 				selectableRows="multiple"
+				handlePageChange={(newPageIndex, newPageSize) => {
+					setLogItems([
+						`page change - index:${newPageIndex} | size:${newPageSize}`,
+						...logItems,
+					]);
+				}}
 				handleCreate={() => {
 					const newRow: IDataTableMockData = {
 						id: `new-row-${Math.random()}`,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -132,7 +132,7 @@ export const Table = <T extends Record<string, any>>({
 		const currentPage = pageIndex + 1;
 
 		if (currentPage > pageCount) {
-			const finalPageIndex = pageCount - 1; // index is 0-based
+			const finalPageIndex = Math.max(0, pageCount - 1); // index is 0-based
 
 			gotoPage(finalPageIndex);
 			setRootLevelPageIndex(finalPageIndex);
@@ -271,7 +271,7 @@ export const Table = <T extends Record<string, any>>({
 						itemsPerPageOptions={itemsPerPageOptions}
 						onPageChange={(e, newIndex) => {
 							e?.preventDefault();
-							const nextIndex = newIndex - 1;
+							const nextIndex = Math.max(0, newIndex - 1);
 							gotoPage(nextIndex);
 							setRootLevelPageIndex(nextIndex);
 							handlePageChange(nextIndex, pageSize);
@@ -283,7 +283,7 @@ export const Table = <T extends Record<string, any>>({
 							// when the user has chosen more rows, and there are thus fewer pages, check if we need to update the current page
 							const maxPageIndex = Math.ceil(rowCount / newItemsPerPage);
 							if (pageIndex > maxPageIndex) {
-								const newIndex = maxPageIndex - 1;
+								const newIndex = Math.max(0, maxPageIndex - 1);
 								gotoPage(newIndex);
 								handlePageChange(newIndex, newItemsPerPage);
 							} else {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -129,6 +129,8 @@ export const Table = <T extends Record<string, any>>({
 	const rowCount = rows.length;
 	// update shown page if necessary
 	useEffect(() => {
+		if (pageCount === 0) return;
+
 		const currentPage = pageIndex + 1;
 
 		if (currentPage > pageCount) {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -129,7 +129,7 @@ export const Table = <T extends Record<string, any>>({
 	const rowCount = rows.length;
 	// update shown page if necessary
 	useEffect(() => {
-		if (pageCount === 0) return;
+		if (pageCount === 0) return; // no data, no need to update
 
 		const currentPage = pageIndex + 1;
 
@@ -139,7 +139,7 @@ export const Table = <T extends Record<string, any>>({
 			gotoPage(finalPageIndex);
 			setRootLevelPageIndex(finalPageIndex);
 			handlePageChange(finalPageIndex, pageSize);
-		} else if (pageCount > 0 && currentPage === 0) {
+		} else if (currentPage === 0) {
 			gotoPage(0);
 			setRootLevelPageIndex(0);
 			handlePageChange(0, pageSize);


### PR DESCRIPTION
[Link to updated Table story](https://deploy-preview-431--neo-react-library-storybook.netlify.app/?path=/story/components-table--editable-data)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [ ] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [ ] tagged `@avaya-dux/dux-devs`

Shrisha pointed out that the returned page index when the table has no data is -1, which causes issues. I have fixed the negative index by adding `Math.max` to index calculations.

You can see a repro in [this codesanbox](https://codesandbox.io/p/sandbox/table-bug-repro-kh3vyd?file=%2Fsrc%2FApp.js%3A20%2C39), or the gif 👇 
![2024-06-24 14 41 54](https://github.com/avaya-dux/neo-react-library/assets/55896546/1bf21e73-2aba-41b2-9c9c-69e7aeb72d9d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed potential out-of-bounds issues by ensuring index calculations in the Table component are non-negative.
  - Added logic to skip updates when `pageCount` is 0, preventing unnecessary operations.

- **New Features**
  - Introduced a `handlePageChange` function to the `EditableData` component in storybook, logging page index and size information for better debugging and insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->