### PR TITLE
Making onClose required and fixing story

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.26",
+	"version": "1.1.27",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Modal/BasicModal/BasicModal.stories.tsx
+++ b/src/components/Modal/BasicModal/BasicModal.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta } from "@storybook/react";
 
 import { Button } from "components/Button";
 
+import catImg from "components/Image/200by300image.jpeg";
 import useModal from "../useModal";
 import { BasicModal, type BasicModalProps } from "./BasicModal";
-import catImg from "components/Image/200by300image.jpeg";
 
 export default {
 	title: "Components/Modal",

--- a/src/components/Modal/BasicModal/BasicModal.stories.tsx
+++ b/src/components/Modal/BasicModal/BasicModal.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from "components/Button";
 
 import useModal from "../useModal";
 import { BasicModal, type BasicModalProps } from "./BasicModal";
+import catImg from "components/Image/200by300image.jpeg";
 
 export default {
 	title: "Components/Modal",
@@ -84,7 +85,7 @@ export const BasicModalExampleWithDiffContent = () => {
 					longer text to see how it <strong>wraps</strong> and aligns
 				</p>
 				<br />
-				<img src="https://placekitten.com/g/200/300" alt="A cat" />
+				<img src={catImg} alt="A cat" />
 			</BasicModal>
 		</>
 	);

--- a/src/components/Modal/BasicModal/BasicModal.tsx
+++ b/src/components/Modal/BasicModal/BasicModal.tsx
@@ -32,7 +32,7 @@ export const BasicModal = forwardRef(
 			children,
 			closeButtonLabel = "Close",
 			onClose,
-			open,
+			open = false,
 			title,
 			id,
 			...rest
@@ -42,6 +42,10 @@ export const BasicModal = forwardRef(
 		const generatedId = useId();
 		id = id || generatedId;
 		const buttons = "actions" in rest ? rest.actions : null;
+
+		if (!onClose) {
+			console.error("onClose prop is required.");
+		}
 
 		const onKeyDown = useCallback(
 			(e: KeyboardEvent) => {


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-433--neo-react-library-storybook.netlify.app/?path=/story/components-modal--basic-modal-example-with-diff-content)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

onClose handler should be required. I also fixed a broken image link in one of the stories.

`@avaya-dux/dux-design`: No review required.


`@avaya-dux/dux-devs`: Added console.error to alert developer the onClose is required if they don't provide it.

- Fixed broken cat image.

<img width="831" alt="image" src="https://github.com/avaya-dux/neo-react-library/assets/3535271/7e1ebffb-7b1b-4bbc-8770-c01c47587b32">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated `BasicModal` to use a high-quality local image instead of a placeholder image.
  
- **Bug Fixes**
  - Default value for the `open` prop in `BasicModal` is now set to `false` if not provided.
  - Added error logging if the `onClose` prop is missing in `BasicModal`.

- **Chores**
  - Incremented version from "1.1.26" to "1.1.27" in `package.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->