### PR TITLE
NEO-1966 Multi-select visual improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.29",
+	"version": "1.1.30",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Select/InternalComponents/MultiSelect.css
+++ b/src/components/Select/InternalComponents/MultiSelect.css
@@ -7,6 +7,7 @@
   color: var(--input-font-color);
   border: none;
   flex-shrink: 0;
+  order: 2;
   
   &:hover {
     cursor: pointer;

--- a/src/components/Select/InternalComponents/MultiSelect.css
+++ b/src/components/Select/InternalComponents/MultiSelect.css
@@ -6,7 +6,8 @@
   background-color: var(--input-background-color);
   color: var(--input-font-color);
   border: none;
-
+  flex-shrink: 0;
+  
   &:hover {
     cursor: pointer;
   }

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -235,10 +235,7 @@ export const MultiSelect = () => {
 							&nbsp;
 						</button>
 					</div>
-
-					{chipsToDisplay}
-				</span>
-				<button
+					<button
 					aria-label="clear selections"
 					className={clsx(
 						"neo-input-edit__icon neo-icon-end",
@@ -249,6 +246,9 @@ export const MultiSelect = () => {
 					disabled={selectedItems.length === 0}
 					onClick={() => setSelectedItems([])}
 				/>
+					{chipsToDisplay}
+				</span>
+
 			</span>
 
 			<div

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -219,6 +219,18 @@ export const MultiSelect = () => {
 			)}
 		>
 			<span {...restToggleProps} className="neo-multiselect-combo__header">
+				{/* put button before span so that it gets tab order first */}	
+				<button
+					aria-label="clear selections"
+					className={clsx(
+						"neo-input-edit__icon neo-icon-end",
+						"neo-multiselect-clear-icon-button",
+						selectedItems.length === 0 && "neo-display-none",
+					)}
+					type="button"
+					disabled={selectedItems.length === 0}
+					onClick={() => setSelectedItems([])}
+				/>
 				<span
 					ref={chipContainerRef}
 					key="multiselect-chip-container"
@@ -234,17 +246,6 @@ export const MultiSelect = () => {
 							&nbsp;
 						</button>
 					</div>
-					<button
-						aria-label="clear selections"
-						className={clsx(
-							"neo-input-edit__icon neo-icon-end",
-							"neo-multiselect-clear-icon-button",
-							selectedItems.length === 0 && "neo-display-none",
-						)}
-						type="button"
-						disabled={selectedItems.length === 0}
-						onClick={() => setSelectedItems([])}
-					/>
 					{chipsToDisplay}
 				</span>
 			</span>

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -224,7 +224,13 @@ export const MultiSelect = () => {
 				isOpen && "neo-multiselect--active",
 			)}
 		>
-			<span {...restToggleProps} className="neo-multiselect-combo__header">
+			<span
+				{...restToggleProps}
+				className={clsx(
+					"neo-multiselect-combo__header",
+					"neo-multiselect-combo__header--focus-visible",
+				)}
+			>
 				{/* put button before span so that it gets tab order first */}
 				<button
 					aria-label="clear selections"

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -19,9 +19,8 @@ import { Tooltip } from "components/Tooltip";
 
 import log from "loglevel";
 import { Keys, reactNodeToString } from "utils";
-import { ar } from "@faker-js/faker";
 const logger = log.getLogger("multiselect-logger");
-logger.enableAll();
+logger.disableAll();
 
 export const MultiSelect = () => {
 	const {
@@ -236,19 +235,18 @@ export const MultiSelect = () => {
 						</button>
 					</div>
 					<button
-					aria-label="clear selections"
-					className={clsx(
-						"neo-input-edit__icon neo-icon-end",
-						"neo-multiselect-clear-icon-button",
-						selectedItems.length === 0 && "neo-display-none",
-					)}
-					type="button"
-					disabled={selectedItems.length === 0}
-					onClick={() => setSelectedItems([])}
-				/>
+						aria-label="clear selections"
+						className={clsx(
+							"neo-input-edit__icon neo-icon-end",
+							"neo-multiselect-clear-icon-button",
+							selectedItems.length === 0 && "neo-display-none",
+						)}
+						type="button"
+						disabled={selectedItems.length === 0}
+						onClick={() => setSelectedItems([])}
+					/>
 					{chipsToDisplay}
 				</span>
-
 			</span>
 
 			<div

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -18,7 +18,8 @@ import "./MultiSelect.css";
 import { Tooltip } from "components/Tooltip";
 
 import log from "loglevel";
-import { reactNodeToString } from "utils";
+import { Keys, reactNodeToString } from "utils";
+import { ar } from "@faker-js/faker";
 const logger = log.getLogger("multiselect-logger");
 logger.enableAll();
 
@@ -158,29 +159,30 @@ export const MultiSelect = () => {
 		...restToggleProps
 	} = getToggleButtonProps({
 		onKeyDown: (event) => {
-			if (event.key === "Enter") {
-				if (event.target instanceof HTMLElement) {
+			// Handle Enter key OR SPACE key press on the button
+			if (event.key === Keys.ENTER || event.key === Keys.SPACE) {
+				if (event.target instanceof HTMLButtonElement) {
+					const ariaLabel = event.target.getAttribute("aria-label");
+
 					logger.debug(
-						`Enter key pressed on button with aria-label: ${event.target.getAttribute("aria-label")}`,
+						`Enter key pressed on button with aria-label: ${ariaLabel}`,
 					);
-				}
-				// hacky way to avoid clicking on the aria labelled button
-				if (
-					event.target instanceof HTMLElement &&
-					event.target.getAttribute("aria-label") === null
-				) {
-					logger.debug("aria-label is null, returning");
-					return;
-				}
-				try {
-					// For some reason, the click event is not being dispatched by Downshift on Enter key press. Let us do it manually.
-					const clickEvent = new MouseEvent("click", {
-						bubbles: true, // Make the event bubble up
-						cancelable: true, // Make the event cancellable
-					});
-					event.target.dispatchEvent(clickEvent);
-				} catch (error) {
-					logger.error("Error dispatching click event:", error);
+
+					if (
+						ariaLabel?.toLowerCase().startsWith("remove") ||
+						ariaLabel?.toLowerCase().startsWith("clear")
+					) {
+						try {
+							// For some reason, the click event is not being dispatched by Downshift on Enter key press. Let us do it manually.
+							const clickEvent = new MouseEvent("click", {
+								bubbles: true, // Make the event bubble up
+								cancelable: true, // Make the event cancellable
+							});
+							event.target.dispatchEvent(clickEvent);
+						} catch (error) {
+							logger.error("Error dispatching click event:", error);
+						}
+					}
 				}
 			}
 		},

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -28,7 +28,7 @@ export const MultiSelect = () => {
 			getMenuProps,
 			getToggleButtonProps,
 			isOpen,
-			selectItem: toggleItem, // NOTE: I've adjusted the hook for this case (multi-select) such that the "select" is actually a "toggle" now,
+			selectItem: toggleItem, // NOTE: I've adjusted the hook for this case (multi-select) such that the "select" is actually a "toggle" now
 		},
 		optionProps: { selectedItems, setSelectedItems, collapse },
 		selectProps: {
@@ -158,7 +158,8 @@ export const MultiSelect = () => {
 		...restToggleProps
 	} = getToggleButtonProps({
 		onKeyDown: (event) => {
-			// Handle Enter key OR SPACE key press on the button
+			// For some reason, the click event is not being dispatched by Downshift on Enter key press.
+			// Let us do it manually on behalf of Chip Close buttons.
 			if (event.key === Keys.ENTER || event.key === Keys.SPACE) {
 				if (event.target instanceof HTMLButtonElement) {
 					const ariaLabel = event.target.getAttribute("aria-label");
@@ -172,7 +173,6 @@ export const MultiSelect = () => {
 						ariaLabel?.toLowerCase().startsWith("clear")
 					) {
 						try {
-							// For some reason, the click event is not being dispatched by Downshift on Enter key press. Let us do it manually.
 							const clickEvent = new MouseEvent("click", {
 								bubbles: true, // Make the event bubble up
 								cancelable: true, // Make the event cancellable

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -159,7 +159,7 @@ export const MultiSelect = () => {
 	} = getToggleButtonProps({
 		onKeyDown: (event) => {
 			// For some reason, the click event is not being dispatched by Downshift on Enter key press.
-			// Let us do it manually on behalf of Chip Close buttons.
+			// Let us do it manually on behalf of Chip Close and Clear All buttons.
 			if (event.key === Keys.ENTER || event.key === Keys.SPACE) {
 				if (event.target instanceof HTMLButtonElement) {
 					const ariaLabel = event.target.getAttribute("aria-label");

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -219,7 +219,7 @@ export const MultiSelect = () => {
 			)}
 		>
 			<span {...restToggleProps} className="neo-multiselect-combo__header">
-				{/* put button before span so that it gets tab order first */}	
+				{/* put button before span so that it gets tab order first */}
 				<button
 					aria-label="clear selections"
 					className={clsx(

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -93,6 +93,7 @@ export const MultiSelectSearchable = () => {
 							disabled={disabled}
 							placeholder={placeholder}
 							onKeyDown={(e) => {
+								logger.debug({ onKeyDownCalled: e.key });
 								if (
 									e.key === Keys.ENTER &&
 									filteredOptions.length === 1 &&
@@ -113,23 +114,21 @@ export const MultiSelectSearchable = () => {
 								setInputValue(e.target.value);
 							}}
 						/>
-
-						<button
-							aria-label="clear selections"
-							className={clsx(
-								"neo-input-edit__icon neo-icon-end",
-								"neo-multiselect-clear-icon-button",
-								selectedItems.length === 0 && "neo-display-none",
-							)}
-							type="button"
-							disabled={selectedItems.length === 0}
-							onClick={() => setSelectedItems([])}
-						/>
 					</div>
 
 					{selectedItemsAsChips}
 				</span>
-
+				<button
+					aria-label="clear selections"
+					className={clsx(
+						"neo-input-edit__icon neo-icon-end",
+						"neo-multiselect-clear-icon-button",
+						selectedItems.length === 0 && "neo-display-none",
+					)}
+					type="button"
+					disabled={selectedItems.length === 0}
+					onClick={() => setSelectedItems([])}
+				/>
 				<input
 					className="neo-display-none"
 					id={id}

--- a/src/components/Select/Select.cy.tsx
+++ b/src/components/Select/Select.cy.tsx
@@ -80,7 +80,7 @@ describe("Single Select Searchable Scrolling Tests", () => {
 });
 
 describe("Multi Select Scrolling Tests", () => {
-	it("Select apple, broccoli, pear, banana and the chip should show +2 on it", () => {
+	it("Select apple, broccoli, pear, banana and the chip should show +1 on it", () => {
 		cy.mount(<CollapsedMultiSelect />);
 
 		// open the select
@@ -98,9 +98,9 @@ describe("Multi Select Scrolling Tests", () => {
 		// select option banana
 		cy.get("[role='listbox']").first().contains("li", "Banana").first().click();
 		// select chips and assert there are 3 chips
-		cy.get(".neo-chip.neo-chip--default").should("have.length", 3);
+		cy.get(".neo-chip.neo-chip--default").should("have.length", 4);
 		// select the collapsed chip
-		const collapsedChip = cy.get(".neo-chip.neo-chip--default").contains("+2");
+		const collapsedChip = cy.get(".neo-chip.neo-chip--default").contains("+1");
 		// assert collapsedChip is visible
 		collapsedChip.should("be.visible");
 		// assert collapsedChip has aria-describedby attribute with non-empty value

--- a/src/components/Select/Select.cy.tsx
+++ b/src/components/Select/Select.cy.tsx
@@ -83,8 +83,9 @@ describe("Multi Select Scrolling Tests", () => {
 	it("Select apple, broccoli, pear, banana and the chip should show +1 on it", () => {
 		cy.mount(<CollapsedMultiSelect />);
 
-		// open the select
-		cy.get("span button").first().click();
+		// open the select by clicking on the toggle button
+		cy.get("span button").eq(1).click();
+
 		// select option apple
 		cy.get("[role='listbox']").first().contains("li", "Apple").first().click();
 		// select option broccoli

--- a/src/components/Select/Select.test.jsx
+++ b/src/components/Select/Select.test.jsx
@@ -177,10 +177,10 @@ describe("Select", () => {
 			});
 
 			it("passes aria-labelledby to button element", () => {
-				const toggleElement = screen.getAllByRole("button")[0];
+				const buttonElement = screen.getAllByRole("button")[0];
 				const expectedAttributes = ["aria-labelledby"];
 				expectedAttributes.forEach((attribute) =>
-					expect(toggleElement).toHaveAttribute(attribute),
+					expect(buttonElement).toHaveAttribute(attribute),
 				);
 			});
 

--- a/src/components/Select/Select.test.jsx
+++ b/src/components/Select/Select.test.jsx
@@ -57,10 +57,10 @@ describe("Select", () => {
 			const buttons = screen.getAllByRole("button");
 			expect(buttons).toHaveLength(2);
 
-			const toggleButton = buttons[0];
+			const toggleButton = buttons[1];
 			expect(toggleButton).toHaveClass("neo-multiselect__header");
 
-			const clearButton = buttons[1];
+			const clearButton = buttons[0];
 			expect(clearButton).toHaveClass("neo-multiselect-clear-icon-button");
 			expect(clearButton).toBeDisabled();
 		});
@@ -177,7 +177,7 @@ describe("Select", () => {
 			});
 
 			it("passes aria-labelledby to button element", () => {
-				const buttonElement = screen.getAllByRole("button")[0];
+				const buttonElement = screen.getAllByRole("button")[1];
 				const expectedAttributes = ["aria-labelledby"];
 				expectedAttributes.forEach((attribute) =>
 					expect(buttonElement).toHaveAttribute(attribute),
@@ -251,7 +251,7 @@ describe("Select", () => {
 						<SelectOption>Option 4</SelectOption>
 					</Select>,
 				);
-				const toggleElement = screen.getAllByRole("button")[0];
+				const toggleElement = screen.getAllByRole("button")[1];
 				toggleElement.focus();
 				// open menu
 				await user.keyboard(UserEventKeys.ENTER);
@@ -284,7 +284,7 @@ describe("Select", () => {
 					/>,
 				);
 
-				const defaultSelectHeader = getAllByRole("button")[0];
+				const defaultSelectHeader = getAllByRole("button")[1];
 				expect(defaultSelectHeader).toHaveAttribute("aria-expanded", "false");
 				fireEvent.click(defaultSelectHeader);
 				expect(defaultSelectHeader).toHaveAttribute("aria-expanded", "false");
@@ -310,9 +310,8 @@ describe("Select", () => {
 				);
 
 				const buttons = screen.getAllByRole("button");
-				const toggleButton = buttons[0];
-
-				const clearButton = buttons[1];
+				const clearButton = buttons[0];
+				const toggleButton = buttons[1];
 
 				// open menu
 				toggleButton.focus();
@@ -464,7 +463,7 @@ describe("Select", () => {
 
 			it("does not open content area on click when loading", () => {
 				const { getAllByRole } = renderResult;
-				const defaultSelectHeader = getAllByRole("button")[0];
+				const defaultSelectHeader = getAllByRole("button")[1];
 				expect(defaultSelectHeader).toHaveAttribute("aria-expanded", "false");
 				fireEvent.click(defaultSelectHeader);
 				expect(defaultSelectHeader).toHaveAttribute("aria-expanded", "false");

--- a/src/components/Select/Select.test.jsx
+++ b/src/components/Select/Select.test.jsx
@@ -167,18 +167,28 @@ describe("Select", () => {
 			});
 
 			it("passes the correct props to toggle element", () => {
-				const toggleElement = screen.getAllByRole("button")[0];
-				const expectedAttributes = ["id", "aria-haspopup", "aria-labelledby"];
+				const toggleElement = document.querySelector(
+					".neo-multiselect-combo__header",
+				);
+				const expectedAttributes = ["id", "aria-haspopup"];
 				expectedAttributes.forEach((attribute) =>
 					expect(toggleElement).toHaveAttribute(attribute),
 				);
 			});
 
-			it("toggles aria-expanded prop on click", () => {
+			it("passes aria-labelledby to button element", () => {
 				const toggleElement = screen.getAllByRole("button")[0];
-				expect(toggleElement).toHaveAttribute("aria-expanded", "false");
-				fireEvent.click(toggleElement);
-				expect(toggleElement).toHaveAttribute("aria-expanded", "true");
+				const expectedAttributes = ["aria-labelledby"];
+				expectedAttributes.forEach((attribute) =>
+					expect(toggleElement).toHaveAttribute(attribute),
+				);
+			});
+
+			it("no aria-expanded on toggle element", () => {
+				const toggleElement = document.querySelector(
+					".neo-multiselect-combo__header",
+				);
+				expect(toggleElement).not.toHaveAttribute("aria-expanded", "false");
 			});
 
 			it("sets and clears error text appropriately", () => {

--- a/src/components/Select/Select_shim.css
+++ b/src/components/Select/Select_shim.css
@@ -16,6 +16,10 @@ body .neo-multiselect .neo-multiselect-combo__header {
   flex-wrap: nowrap;
 }
 
+body .neo-multiselect .neo-multiselect-combo__header.neo-multiselect-combo__header--focus-visible:focus-visible {
+  outline: 0;
+}
+
 body .neo-multiselect__content.neo-set-keyboard-focus,
 body .neo-multiselect__content:focus-visible {
   outline-offset: 1px;

--- a/src/components/Select/Select_shim.css
+++ b/src/components/Select/Select_shim.css
@@ -6,8 +6,14 @@
 }
 
 .neo-multiselect
-  span.neo-multiselect-combo__header.neo-multiselect-combo__header--no-after:after {
+  span.neo-multiselect-combo__header.neo-multiselect-combo__header--no-after:after,
+.neo-multiselect
+  span.neo-multiselect-combo__header .neo-multiselect__padded-container button.neo-multiselect__header.neo-multiselect__header--no-after::after {
   display: none;
+}
+
+body .neo-multiselect .neo-multiselect-combo__header {
+  flex-wrap: nowrap;
 }
 
 body .neo-multiselect__content.neo-set-keyboard-focus,
@@ -67,6 +73,7 @@ div.neo-multiselect
   input.neo-input {
   border: 0;
   display: inline-block;
+  width: 12ch;
 }
 
 div.neo-multiselect:not(.neo-multiselect--small)

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -3,7 +3,7 @@ const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
 // 60 is the space reserved for the badge chip (35px) and toggle button (25px)
-const MIN_RESERVED_SPACE = 60
+const MIN_RESERVED_SPACE = 60;
 /**
  * Calculate the number of chips that can be displayed in the container
  * @param {number} containerWidth - The width of the container.

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -2,8 +2,8 @@ import log from "loglevel";
 const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
-// 60px is the space reserved for the badge chip, clear button and some padding
-const MIN_RESERVED_SPACE = 60;
+// 60 is the space reserved for the badge chip (35px) and toggle button (25px)
+const MIN_RESERVED_SPACE = 60
 /**
  * Calculate the number of chips that can be displayed in the container
  * @param {number} containerWidth - The width of the container.

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -2,7 +2,7 @@ import log from "loglevel";
 const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
-// 120px is the space reserved for the badge chip, the 2 buttons and some padding
+// 60px is the space reserved for the badge chip, clear button and some padding
 const MIN_RESERVED_SPACE = 60;
 /**
  * Calculate the number of chips that can be displayed in the container

--- a/src/components/Select/utils/multiSelectHelper.ts
+++ b/src/components/Select/utils/multiSelectHelper.ts
@@ -3,7 +3,7 @@ const logger = log.getLogger("multiselect-helper-logger");
 logger.disableAll();
 
 // 120px is the space reserved for the badge chip, the 2 buttons and some padding
-const MIN_RESERVED_SPACE = 120;
+const MIN_RESERVED_SPACE = 60;
 /**
  * Calculate the number of chips that can be displayed in the container
  * @param {number} containerWidth - The width of the container.

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -5,7 +5,7 @@ import { type Dispatch, type SetStateAction, useState } from "react";
 import type { SelectOptionProps } from "./SelectTypes";
 
 const logger = log.getLogger("use-downshfit");
-logger.disableAll();
+logger.enableAll();
 
 const createOptionValue = "neo-select-create-option";
 
@@ -256,13 +256,13 @@ const DownshiftWithMultipleSelectProps = (
 		stateReducer: (state, actionAndChanges) => {
 			const { changes, type } = actionAndChanges;
 			const isOpen = changes.isOpen ? !(disabled || loading) : false;
-			logger.debug({ isOpen, type, changes });
 			const { selectedItem } = changes;
 
 			const selectedItemsValues = selectedItems.map((item) => item.value);
 			const shouldRemoveItem = selectedItemsValues.includes(
 				selectedItem?.value,
 			);
+			logger.debug(JSON.stringify({ isOpen, type, changes, shouldRemoveItem }));
 
 			switch (type) {
 				case useSelect.stateChangeTypes.ToggleButtonClick:
@@ -291,6 +291,7 @@ const DownshiftWithMultipleSelectProps = (
 					};
 
 				case useSelect.stateChangeTypes.FunctionSelectItem:
+					logger.debug("FunctionSelectItem case: ", changes);
 					// `onSelectedItemChange` handles most use-cases, but this reducer step
 					// is needed to support removing items via `Chip` click and input `backspace`
 					if (selectedItem && selectedItems.includes(selectedItem)) {

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -5,7 +5,7 @@ import { type Dispatch, type SetStateAction, useState } from "react";
 import type { SelectOptionProps } from "./SelectTypes";
 
 const logger = log.getLogger("use-downshfit");
-logger.enableAll();
+logger.disableAll();
 
 const createOptionValue = "neo-select-create-option";
 


### PR DESCRIPTION
### Reduced gap when collapsed:
[Collapsed](https://deploy-preview-435--neo-react-library-storybook.netlify.app/?path=/story/components-select--collapsed-multi-select)
[Collapsed Narrow](https://deploy-preview-435--neo-react-library-storybook.netlify.app/?path=/story/components-select--collapsed-narrow-multi-select)

### Visual improvements in all favors of multi-selects:
[Basic Selects](https://deploy-preview-435--neo-react-library-storybook.netlify.app/?path=/story/components-select--basic-selects)
[Searchable](https://deploy-preview-435--neo-react-library-storybook.netlify.app/?path=/story/components-select--searchable)
[Creatable](https://deploy-preview-435--neo-react-library-storybook.netlify.app/?path=/story/components-select--creatable)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY: 
- visual improvements
- no regression on a11y and functionalities
- 
`@avaya-dux/dux-design`:  Here are the improvements
- Collapse improvement: gap between +n and X is reduced; 
[See Matt's comments in initial PR](https://github.com/avaya-dux/neo-react-library/pull/427#issuecomment-2181171151)
- Clicking anywhere in select works (right now it only works on the line after the selected chips).
- Clear icon and down chevron icon are centered when the select has multiple lines.
- Clear icon does not overlap chips.
[See Matt's comments in initial PR](https://github.com/avaya-dux/neo-react-library/pull/290#issuecomment-1841695805) for context.

`@avaya-dux/dux-devs`: 
- CSS changes
- Some tricky code added to simulate keydown event on close buttons of chips
- Tests updated

**EXAMPLE IMAGE(S):**
| Select | Before | After |
|----------|----------|----------|
| Collapse | <img width="394" alt="collapse before" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/670806cc-f64a-458c-b844-f88453dc641e">|<img width="383" alt="collapse after" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/f0dfc02b-7690-4128-b095-ea98d4f41e3d">|
| Narrow Collapse | <img width="244" alt="collapse narrow before" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/e62998fa-b5be-4006-b343-f58613612865"> | <img width="245" alt="collapse narrow after" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/42327456-0e8d-4532-b36a-2c525186e5ff"> |
| Multi Select | <img width="396" alt="multiselect before" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/77df1140-84bc-42b6-9019-e06834b6d945"> | <img width="403" alt="multiselect after" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/fa2db679-2bb8-4a27-b430-d57a66f36839">|
| Searchable | <img width="387" alt="searchable before" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/9529d013-88ab-4683-8c8a-9611d9e41b8a"> | <img width="393" alt="searchable after" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/c2ee5111-8d9e-47a2-abc5-03fcecdffee8"> |
| Creatable | <img width="399" alt="created before" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/0c0fbb5f-9552-4e37-b36a-1ab1b6e26225"> | <img width="411" alt="created after" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/6629c971-dd9e-400f-996d-a30df58fc3f0"> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced multi-select component with better key event handling and logging.
  
- **Bug Fixes**
  - Improved styling and layout in the multi-select component for better visibility and layout of headers, buttons, and input elements.
  - Updated test cases ensuring accurate display counts for selected items in multi-select components.
  
- **Refactor**
  - Adjusted minimum reserved space for elements in the multi-select component from 120px to 60px.
  
- **Chores**
  - Updated version in `package.json` from "1.1.29" to "1.1.30".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->