### PR TITLE
NEO-2306 // Table bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.28",
+	"version": "1.1.29",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",
@@ -60,8 +60,8 @@
 		"react-table": "7.8.0"
 	},
 	"devDependencies": {
-		"@avaya/neo": "3.81.7",
-		"@avaya/neo-icons": "1.8.11",
+		"@avaya/neo": "3.81.8",
+		"@avaya/neo-icons": "1.8.12",
 		"@biomejs/biome": "1.8.2",
 		"@faker-js/faker": "8.4.1",
 		"@storybook/addon-a11y": "7.6.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.27",
+	"version": "1.1.28",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -373,6 +373,13 @@ export const EditableData = () => {
 				data={data}
 				readonly={readonly}
 				selectableRows="multiple"
+				initialStatePageSize={5}
+				handlePageChange={(newPageIndex, newPageSize) => {
+					setLogItems([
+						`page change - index:${newPageIndex} | size:${newPageSize}`,
+						...logItems,
+					]);
+				}}
 				handleCreate={() => {
 					const newRow: IDataTableMockData = {
 						id: `new-row-${Math.random()}`,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -127,20 +127,19 @@ export const Table = <T extends Record<string, any>>({
 		pageCount,
 	} = instance;
 	const rowCount = rows.length;
-	// update shown page if necessary
-	useEffect(() => {
-		const currentPage = pageIndex + 1;
 
+	// this `useEffect` handles the edge cases of page change logic
+	useEffect(() => {
+		if (pageCount === 0) return; // no table data, ignore (effectively memoizing `pageIndex`)
+
+		// use-case: user deletes all rows on the last page while on the last page
+		const currentPage = pageIndex + 1;
 		if (currentPage > pageCount) {
-			const finalPageIndex = pageCount - 1; // index is 0-based
+			const finalPageIndex = Math.max(0, pageCount - 1); // index is 0-based
 
 			gotoPage(finalPageIndex);
 			setRootLevelPageIndex(finalPageIndex);
 			handlePageChange(finalPageIndex, pageSize);
-		} else if (pageCount > 0 && currentPage === 0) {
-			gotoPage(0);
-			setRootLevelPageIndex(0);
-			handlePageChange(0, pageSize);
 		}
 	}, [pageSize, pageCount, pageIndex, gotoPage, handlePageChange]);
 
@@ -271,7 +270,7 @@ export const Table = <T extends Record<string, any>>({
 						itemsPerPageOptions={itemsPerPageOptions}
 						onPageChange={(e, newIndex) => {
 							e?.preventDefault();
-							const nextIndex = newIndex - 1;
+							const nextIndex = Math.max(0, newIndex - 1);
 							gotoPage(nextIndex);
 							setRootLevelPageIndex(nextIndex);
 							handlePageChange(nextIndex, pageSize);
@@ -283,7 +282,7 @@ export const Table = <T extends Record<string, any>>({
 							// when the user has chosen more rows, and there are thus fewer pages, check if we need to update the current page
 							const maxPageIndex = Math.ceil(rowCount / newItemsPerPage);
 							if (pageIndex > maxPageIndex) {
-								const newIndex = maxPageIndex - 1;
+								const newIndex = Math.max(0, maxPageIndex - 1);
 								gotoPage(newIndex);
 								handlePageChange(newIndex, newItemsPerPage);
 							} else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,15 +20,15 @@
   resolved "https://registry.yarnpkg.com/@atomic-layout/core/-/core-0.14.1.tgz#3d69be5f79775f11b8008f18bc603b04a2141ccd"
   integrity sha512-o5nhk/1djuKzB20C2LSOuetTDytsbGg4c0UfxXkq1pqoaN3hKJcHPYF9nV+p6+P5CWqNBaaJddZ32OsFSppULQ==
 
-"@avaya/neo-icons@1.8.11":
-  version "1.8.11"
-  resolved "https://registry.yarnpkg.com/@avaya/neo-icons/-/neo-icons-1.8.11.tgz#f44b990153f5023e4cc404df84cdea975947f87b"
-  integrity sha512-dPCoIqEV+3ksjt1sSYryu/1nBDskJzeACt2LCjVcHXo3xB1Lu2DxD76EVarojcK+WWg7yI6pHDeNvMVB0JtUGQ==
+"@avaya/neo-icons@1.8.12":
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/@avaya/neo-icons/-/neo-icons-1.8.12.tgz#aa73ae33dd32507351680e1e4d6b53967f983a4e"
+  integrity sha512-HJFsaJme7m3SMEMEtOuIiOnHVenUAZ7HVR1X2vagqPWhfgDkOq1agFszu2vhCPwUnO6HZIyCkGXrIbxTly1+VQ==
 
-"@avaya/neo@3.81.7":
-  version "3.81.7"
-  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.81.7.tgz#f9abf3a424fa537307cdd2e463f59f2968cdde55"
-  integrity sha512-9L+I2k2PbOByn3h/7rXADCiBO1Bz65+G+Qd9ZMSDZgoVOFpvbGsKcekxOlMeUc2muaUkmK2Ks3rqzK7WKF62uQ==
+"@avaya/neo@3.81.8":
+  version "3.81.8"
+  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.81.8.tgz#2e92e5f58b3d1121f0e76fa675d9c3d2916e8ddb"
+  integrity sha512-N7c0aXo67SQov+qGzCwDyVuS5LfGwfnuQmiUNO3rrnqiYqocG6UXslcjl0eauKwGWfgBjZ5heUpe0Ydpq9fAsw==
 
 "@aw-web-design/x-default-browser@1.4.126":
   version "1.4.126"
@@ -13124,16 +13124,7 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13215,14 +13206,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14443,7 +14427,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14456,15 +14440,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
[Link to updated Table story "Editable Data"](https://deploy-preview-436--neo-react-library-storybook.netlify.app/?path=/story/components-table--editable-data)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

Resolving an issue in the Table where, when the data is removed, `handlePageChange` can cause the component to break. This covers that issue, adds tests for it, and bumps the neo-react version so that I can push this fix to the respective team ASAP.

`@avaya-dux/dux-devs`: test any edge cases for pagination that you can think of. Note that the storybook story tells you when the handler is called and with what data. The actual fix is returning early in the `useEffect` and ensuring that we never return negative page indexes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page change handling in the `EditableData` component, allowing updates to log items based on page index and size changes.

- **Bug Fixes**
  - Improved the `Table` component to better handle edge cases during page changes, ensuring correct page navigation even when all rows on the last page are deleted.

- **Tests**
  - Added new test cases to verify correct behavior when data is removed, re-added, and when the new data set has fewer pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->