### PR TITLE
NEO-2308: Table component: Add showSearch prop to optionally hide the search input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.27",
+	"version": "1.1.28",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -442,7 +442,11 @@ export const PaginationPushedDown = () => (
 );
 
 export const BareBones = () => (
-	<Table columns={FilledFields.columns} showSearch={false} data={[...FilledFields.data]} />
+	<Table
+		columns={FilledFields.columns}
+		showSearch={false}
+		data={[...FilledFields.data]}
+	/>
 );
 
 export const WithRowSeparator = () => (

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -442,7 +442,7 @@ export const PaginationPushedDown = () => (
 );
 
 export const BareBones = () => (
-	<Table columns={FilledFields.columns} data={[...FilledFields.data]} />
+	<Table columns={FilledFields.columns} showSearch={false} data={[...FilledFields.data]} />
 );
 
 export const WithRowSeparator = () => (

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -85,6 +85,7 @@ export const Table = <T extends Record<string, any>>({
 	pushPaginationDown = false,
 	showRowSeparator = false,
 	showRowHeightMenu = true,
+	showSearch = true,
 	itemDisplayTooltipPosition = "auto",
 	itemsPerPageTooltipPosition = "auto",
 	translations,
@@ -227,6 +228,7 @@ export const Table = <T extends Record<string, any>>({
 						handleRowHeightChange={onRowHeightChangeHandler}
 						rowHeight={rowHeightValue}
 						showRowHeightMenu={showRowHeightMenu}
+						showSearch={showSearch}
 						instance={instance}
 						readonly={readonly}
 						translations={toolbarTranslations}

--- a/src/components/Table/TableComponents/TableToolbar.tsx
+++ b/src/components/Table/TableComponents/TableToolbar.tsx
@@ -116,18 +116,18 @@ export const TableToolbar = <T extends Record<string, any>>({
 			>
 				<div className="neo-form">
 					{showSearch && (
-				<TextInput
-					aria-label={translations.searchInputPlaceholder}
-					placeholder={translations.searchInputPlaceholder}
-					startIcon="search"
-					value={search}
-					onChange={(e) => {
-						e.preventDefault();
-						e.stopPropagation();
-						setSearches(e.currentTarget.value);
-					}}
-				/>
-			)}
+						<TextInput
+							aria-label={translations.searchInputPlaceholder}
+							placeholder={translations.searchInputPlaceholder}
+							startIcon="search"
+							value={search}
+							onChange={(e) => {
+								e.preventDefault();
+								e.stopPropagation();
+								setSearches(e.currentTarget.value);
+							}}
+						/>
+					)}
 				</div>
 
 				{allowColumnFilter && (

--- a/src/components/Table/TableComponents/TableToolbar.tsx
+++ b/src/components/Table/TableComponents/TableToolbar.tsx
@@ -29,6 +29,7 @@ export const TableToolbar = <T extends Record<string, any>>({
 	handleRefresh,
 	handleRowHeightChange,
 	showRowHeightMenu,
+	showSearch,
 	rowHeight,
 	instance,
 	readonly = false,
@@ -114,17 +115,19 @@ export const TableToolbar = <T extends Record<string, any>>({
 				style={{ position: "relative" }}
 			>
 				<div className="neo-form">
-					<TextInput
-						aria-label={translations.searchInputPlaceholder}
-						placeholder={translations.searchInputPlaceholder}
-						startIcon="search"
-						value={search}
-						onChange={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							setSearches(e.currentTarget.value);
-						}}
-					/>
+					{showSearch && (
+				<TextInput
+					aria-label={translations.searchInputPlaceholder}
+					placeholder={translations.searchInputPlaceholder}
+					startIcon="search"
+					value={search}
+					onChange={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						setSearches(e.currentTarget.value);
+					}}
+				/>
+			)}
 				</div>
 
 				{allowColumnFilter && (

--- a/src/components/Table/types/TableTypes.ts
+++ b/src/components/Table/types/TableTypes.ts
@@ -21,6 +21,7 @@ interface ToolbarSharedProps<T extends AnyRecord> {
 	handleEdit?: (selectedRow: T) => Promise<void> | void;
 	handleRefresh?: () => Promise<void> | void;
 	showRowHeightMenu?: boolean;
+	showSearch?: boolean;
 	rowHeight?: RowHeight;
 }
 export type TableToolbarProps<T extends AnyRecord> = {


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-438--neo-react-library-storybook.netlify.app/?path=/story/components-table--bare-bones)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

External dev team asked for the ability to optionally hide the Search input field. This PR adds a prop to do so.

`@avaya-dux/dux-design`: Navigate to preview link above and verify table looks right to you when Search field is hidden.

- There are no changes when Search field is shown.
- When Search field is hidden we do not re-arrange any other UI elements.

`@avaya-dux/dux-devs`: Adding a new showSearch prop to hide / show the Search field

- Default is set to true for backwards compatibility
- Updated "Bare Bones" Story so that it sets showSearch to false. (See preview link above)

<img width="1355" alt="image" src="https://github.com/avaya-dux/neo-react-library/assets/3535271/0417cb31-e028-4ed6-a77f-4e98897bf143">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `showSearch` prop to the `Table` component that allows toggling the display of a search input.
  - The `TableToolbar` component now dynamically renders a search input based on the `showSearch` prop.

- **Chores**
  - Updated the library version from `1.1.27` to `1.1.28` in `package.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->