### PR TITLE
React Menu: fix onClick not called when enter or space are pressed on MenuItem

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.test.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.test.jsx
@@ -1,10 +1,10 @@
 import { composeStories } from "@storybook/testing-react";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import log from "loglevel";
 import { vi } from "vitest";
-import * as MenuItemStories from "./MenuItem.stories";
 import { MenuItem } from "./MenuItem";
+import * as MenuItemStories from "./MenuItem.stories";
 
 log.disableAll();
 
@@ -54,7 +54,7 @@ describe("Menu Item Storybook tests", () => {
 			const onKeyDown = vi.fn();
 			const onClick = vi.fn();
 			const renderResult = render(
-				<MenuItem onKeyDown={onKeyDown} onClick={on}>
+				<MenuItem onKeyDown={onKeyDown} onClick={onClick}>
 					Click Me
 				</MenuItem>,
 			);

--- a/src/components/Menu/MenuItem/MenuItem.test.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.test.jsx
@@ -1,15 +1,74 @@
 import { composeStories } from "@storybook/testing-react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import log from "loglevel";
-
+import { vi } from "vitest";
 import * as MenuItemStories from "./MenuItem.stories";
+import { MenuItem } from "./MenuItem";
 
 log.disableAll();
 
 const { Default, ItemTemplate } = composeStories(MenuItemStories);
 
 describe("Menu Item Storybook tests", () => {
+	describe("Event handlers", () => {
+		it("onClick is called on mouse click", () => {
+			const onClick = vi.fn();
+			const renderResult = render(
+				<MenuItem onClick={onClick}>Click Me</MenuItem>,
+			);
+			const { container } = renderResult;
+			expect(container).toBeDefined();
+			fireEvent.click(screen.getByRole("menuitem"));
+			expect(onClick).toHaveBeenCalled();
+		});
+		it("onClick is called on enter press", () => {
+			const onClick = vi.fn();
+			const renderResult = render(
+				<MenuItem onClick={onClick}>Click Me</MenuItem>,
+			);
+			const { container } = renderResult;
+			expect(container).toBeDefined();
+			fireEvent.keyDown(screen.getByRole("menuitem"), {
+				key: "Enter",
+				code: "Enter",
+				keyCode: 13,
+			});
+			expect(onClick).toHaveBeenCalled();
+		});
+		it("onClick is called on space press", () => {
+			const onClick = vi.fn();
+			const renderResult = render(
+				<MenuItem onClick={onClick}>Click Me</MenuItem>,
+			);
+			const { container } = renderResult;
+			expect(container).toBeDefined();
+			fireEvent.keyDown(screen.getByRole("menuitem"), {
+				key: " ",
+				code: "Space",
+				keyCode: 32,
+			});
+			expect(onClick).toHaveBeenCalled();
+		});
+		it("onKeyDown is called on key down and onClick is not called", () => {
+			const onKeyDown = vi.fn();
+			const onClick = vi.fn();
+			const renderResult = render(
+				<MenuItem onKeyDown={onKeyDown} onClick={on}>
+					Click Me
+				</MenuItem>,
+			);
+			const { container } = renderResult;
+			expect(container).toBeDefined();
+			fireEvent.keyDown(screen.getByRole("menuitem"), {
+				key: " ",
+				code: "Space",
+				keyCode: 32,
+			});
+			expect(onKeyDown).toHaveBeenCalled();
+			expect(onClick).not.toHaveBeenCalled();
+		});
+	});
 	describe("Default", () => {
 		let renderResult;
 		beforeEach(() => {

--- a/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/src/components/Menu/MenuItem/MenuItem.tsx
@@ -1,6 +1,8 @@
 import clsx from "clsx";
 import log from "loglevel";
 import {
+	type KeyboardEvent,
+	type KeyboardEventHandler,
 	type Ref,
 	type RefObject,
 	forwardRef,
@@ -9,6 +11,7 @@ import {
 	useRef,
 } from "react";
 
+import { Keys } from "utils";
 import type { MenuItemProps } from "../MenuTypes";
 
 const logger = log.getLogger("menu-item");
@@ -50,6 +53,8 @@ export const MenuItem = forwardRef(
 			id,
 			isActive = false,
 			tabIndex = 0,
+			onClick,
+			onKeyDown,
 			...rest
 		}: MenuItemProps,
 		ref: Ref<HTMLDivElement>,
@@ -62,6 +67,30 @@ export const MenuItem = forwardRef(
 		logger.debug(
 			`debug menuitem hasFocus = ${hasFocus}, isActive=${isActive}, counter=${counter}`,
 		);
+
+		const handleMenuItemKeyDown: KeyboardEventHandler = (
+			e: KeyboardEvent<HTMLDivElement>,
+		) => {
+			logger.debug("MenuItem handling keydown event ...");
+			if (onKeyDown) {
+				onKeyDown(e);
+				return;
+			}
+
+			switch (e.key) {
+				case Keys.ENTER:
+				case Keys.SPACE:
+					logger.debug("trigger onclick ...");
+					if (onClick && e.target === e.currentTarget) {
+						const clickEvent = new MouseEvent("click", {
+							bubbles: true,
+							cancelable: true,
+						});
+						e.target.dispatchEvent(clickEvent);
+					}
+					break;
+			}
+		};
 
 		// run it in every render
 		useEffect(() => {
@@ -82,6 +111,8 @@ export const MenuItem = forwardRef(
 				ref={localRef}
 				role="menuitem"
 				tabIndex={tabIndex}
+				onKeyDown={handleMenuItemKeyDown}
+				onClick={onClick}
 			>
 				{children}
 			</div>


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-445--neo-react-library-storybook.netlify.app/?path=/story/components-menu--functional-menu)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY 
- fix onClick not called problem on "Enter" or "Space" key press on MenuItem

`@avaya-dux/dux-devs`: 
- add a default keyDown handler to call onClick if present, this should save the users to provide onKeyDown handler themselfves.
- @joe-s-avaya this will make your pr easier. :-)

As shown in below screesshots, pressing "enter" triggers onClick handler
<img width="1689" alt="Screenshot 2024-07-10 at 1 35 46 PM" src="https://github.com/avaya-dux/neo-react-library/assets/31546063/f738e6e8-9831-4345-af4d-16718f0d2e3c">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `MenuItem` component to support keyboard events, improving accessibility.
  
- **Tests**
  - Added tests for `onClick` and `onKeyDown` handlers in the `MenuItem` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->