### PR TITLE
show grab icon for drag icon even if row is disabled

### DIFF
--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -79,8 +79,7 @@
 }
 
 .neo-table tr td.neo-table__dnd-td,
-.neo-table tr.disabled td.neo-table__dnd-td {
-	/* BUG: disabled row is not showing correctly */
+.neo-table tr.disabled:hover:has(td.neo-table__dnd-td) * {
 	cursor: grab;
 }
 

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -79,7 +79,7 @@
 }
 
 .neo-table tr td.neo-table__dnd-td,
-.neo-table tr.disabled:hover:has(td.neo-table__dnd-td) * {
+.neo-table tr.disabled td.neo-table__dnd-td * {
 	cursor: grab;
 }
 


### PR DESCRIPTION
[Link to updated Disabled Rows story](https://deploy-preview-454--neo-react-library-storybook.netlify.app/?path=/story/components-table--disabled-rows)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

All draggable rows should always be draggable, even when the row is disabled—updating the visuals to reflect that properly. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display behavior of disabled table rows by refining CSS selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->