### PR TITLE
add tests for "disabled row" functionality and do some code cleanup

### DIFF
--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -801,6 +801,61 @@ describe("Table", () => {
 			);
 			const disabledCheckbox = disabledTableRows[0].querySelector("input");
 			expect(disabledCheckbox).toBeDisabled();
+			expect(disabledCheckbox).not.toBeChecked();
+
+			// click on the disabled row and confirm that it is still not checked
+			await user.click(disabledCheckbox);
+			expect(disabledCheckbox).not.toBeChecked();
+		});
+
+		it("does not select disabled rows when selecting all", async () => {
+			render(<DisabledRows />);
+
+			// open dropdown, select all rows
+			const dropdown = screen.getByLabelText(
+				FilledFields.translations.header.tableSelectionDropdown,
+			);
+			await user.click(dropdown);
+			const selectAllRows = screen.getByText(
+				`${FilledFields.translations.header.selectAll} (8)`,
+			);
+			await user.click(selectAllRows);
+
+			// confirm that the first body row (skipping over "clear row") is not disabled and is selected
+			const tableRows = screen.getAllByRole("row");
+			const firstBodyRow = tableRows[2];
+			expect(firstBodyRow).not.toHaveClass("disabled");
+			expect(firstBodyRow.querySelector("input")).toBeChecked();
+
+			// confirm that the second row is disabled and is not selected
+			const secondBodyRow = tableRows[3];
+			expect(secondBodyRow).toHaveClass("disabled");
+			expect(secondBodyRow.querySelector("input")).not.toBeChecked();
+		});
+
+		it("does not select disabled rows when selecting all on a page", async () => {
+			render(<DisabledRows />);
+
+			// open dropdown, select all rows
+			const dropdown = screen.getByLabelText(
+				FilledFields.translations.header.tableSelectionDropdown,
+			);
+			await user.click(dropdown);
+			const selectAllRows = screen.getByText(
+				`${FilledFields.translations.header.selectPage} (3)`,
+			);
+			await user.click(selectAllRows);
+
+			// confirm that the first body row (skipping over "clear row") is not disabled and is selected
+			const tableRows = screen.getAllByRole("row");
+			const firstBodyRow = tableRows[2];
+			expect(firstBodyRow).not.toHaveClass("disabled");
+			expect(firstBodyRow.querySelector("input")).toBeChecked();
+
+			// confirm that the second row is disabled and is not selected
+			const secondBodyRow = tableRows[3];
+			expect(secondBodyRow).toHaveClass("disabled");
+			expect(secondBodyRow.querySelector("input")).not.toBeChecked();
 		});
 	});
 

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -88,9 +88,6 @@ const ClearSelectionRow: TableBodyComponentType = ({
 	const shouldShowCheckbox = selectableRows !== "none";
 	const selectedRowCount = Object.keys(selectedRowIds).length;
 
-	// if no rows are selected, return early
-	if (selectedRowCount === 0) return undefined;
-
 	const columnsLength = useMemo(() => {
 		const checkboxColumns = shouldShowCheckbox ? 1 : 0;
 		const dragColumn = canDrag ? 1 : 0;
@@ -162,6 +159,9 @@ const ClearSelectionRow: TableBodyComponentType = ({
 		allTableEnabledRowsAreSelected,
 		allPageEnabledRowsSelected,
 	]);
+
+	// if no rows are selected, return
+	if (selectedRowCount === 0) return undefined;
 
 	return (
 		<tr className="clear-row">

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -2,9 +2,11 @@ import {
 	SortableContext,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { Checkbox } from "components";
 import log from "loglevel";
 import { useContext } from "react";
+
+import { Checkbox } from "components";
+
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
 import type { Row } from "react-table";
@@ -15,10 +17,9 @@ import type { TableBodyProps } from "../types";
 export const logger = log.getLogger("TableComponents/TableBody");
 logger.enableAll();
 
-import "./TableBody_shim.css";
+import { toggleEnabledTableRows } from "../helpers";
 
 import "./TableBody_shim.css";
-import { toggleEnabledTableRows } from "../helpers";
 
 // biome-ignore lint/suspicious/noExplicitAny: we require maximum flexibility here
 type TableBodyComponentType = <T extends Record<string, any>>(


### PR DESCRIPTION
**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

No functional updates, this is only adding tests and some code cleanup. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added test cases to ensure disabled rows in the table are not selectable, even when attempting to select all rows.

- **Refactor**
  - Reordered imports and reorganized code within the `TableBody` component for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->