### PR TITLE
allow users to hide the "clear row" in the body

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -33,6 +33,16 @@ export const Default = () => (
 	<Table {...FilledFields} caption="Storybook Default Table Example" />
 );
 
+export const MultiSelectWithoutHelper = () => (
+	<Table
+		{...FilledFields}
+		caption="Multi select without helper"
+		initialStatePageSize={5}
+		selectableRows="multiple"
+		showRowSelectionHelper={false}
+	/>
+);
+
 export const TooltipPositioning = () => (
 	<Table
 		{...FilledFields}
@@ -371,6 +381,7 @@ export const CustomActions = () => {
 		/>
 	);
 };
+
 export const EditableData = () => {
 	const [data, setData] = useState(FilledFields.data);
 	const [readonly, setReadonly] = useState(false);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -104,6 +104,7 @@ export const Table = <T extends Record<string, any>>({
 	pushPaginationDown = false,
 	showRowSeparator = false,
 	showRowHeightMenu = true,
+	showRowSelectionHelper = true,
 	showSearch = true,
 	itemDisplayTooltipPosition = "auto",
 	itemsPerPageTooltipPosition = "auto",
@@ -350,6 +351,7 @@ export const Table = <T extends Record<string, any>>({
 							handleRowToggled={handleRowToggled}
 							instance={instance}
 							selectableRows={selectableRows}
+							showRowSelectionHelper={showRowSelectionHelper}
 							translations={bodyTranslations}
 						/>
 					</table>
@@ -396,6 +398,7 @@ export const Table = <T extends Record<string, any>>({
 					)}
 				</div>
 			</FilterContext.Provider>
+
 			<DragOverlay>
 				{activeId && selectedRow && (
 					<table

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -40,6 +40,7 @@ export const TableBody: TableBodyComponentType = ({
 	handleRowToggled = () => null,
 	instance,
 	selectableRows,
+	showRowSelectionHelper,
 	translations,
 }) => {
 	const { getTableBodyProps, headers, page, rows } = instance;
@@ -53,11 +54,13 @@ export const TableBody: TableBodyComponentType = ({
 					</tr>
 				) : (
 					<>
-						<ClearSelectionRow
-							instance={instance}
-							selectableRows={selectableRows}
-							translations={translations}
-						/>
+						{showRowSelectionHelper && (
+							<ClearSelectionRow
+								instance={instance}
+								selectableRows={selectableRows}
+								translations={translations}
+							/>
+						)}
 
 						<TableDataRows
 							handleRowToggled={handleRowToggled}

--- a/src/components/Table/types/TableTypes.ts
+++ b/src/components/Table/types/TableTypes.ts
@@ -41,6 +41,7 @@ export type TableHeaderProps<T extends AnyRecord> = {
 } & TableHeaderBodySharedProps<T>;
 
 export type TableBodyProps<T extends AnyRecord> = {
+	showRowSelectionHelper?: boolean;
 	translations: IBodyTranslations;
 } & TableHeaderBodySharedProps<T>;
 
@@ -68,6 +69,7 @@ export type TableProps<T extends AnyRecord> = {
 	initialStatePageSize?: number;
 	defaultSelectedRowIds?: string[];
 	showRowSeparator?: boolean;
+	showRowSelectionHelper?: boolean;
 	summary?: string;
 	containerClassName?: string;
 	translations?: ITableTranslations;


### PR DESCRIPTION
[Link to Table story](https://deploy-preview-456--neo-react-library-storybook.netlify.app/?path=/story/components-table--multi-select-without-helper)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

This adds a prop to hide the "clear row" functionality. The prop defaults to true, this story sets it to false. Easy-peasy. 