### PR TITLE
NEO-2189 switch back to th for empty cell on header

### DIFF
--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -7,7 +7,7 @@ import { DragHandle } from "./DragHandle";
 
 import log from "loglevel";
 export const logger = log.getLogger("TableComponents/DraggableTableRow");
-logger.enableAll();
+logger.disableAll();
 
 const EmptyRow = styled.td`
   background: rgba(127, 207, 250, 0.3);

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -15,7 +15,7 @@ import { StaticTableRow } from "../StaticTableRow";
 import { FilterContext } from "../helpers";
 import type { TableBodyProps } from "../types";
 export const logger = log.getLogger("TableComponents/TableBody");
-logger.enableAll();
+logger.disableAll();
 
 import { toggleEnabledTableRows } from "../helpers";
 

--- a/src/components/Table/TableComponents/TableHeader.tsx
+++ b/src/components/Table/TableComponents/TableHeader.tsx
@@ -128,9 +128,14 @@ export const TableHeader = <T extends Record<string, any>>({
 		<thead>
 			<tr>
 				{canDrag && (
-					<td className="neo-table__dnd-th">
-						<div>&nbsp;</div>
-					</td>
+					<th className="neo-table__dnd-th">
+						<div
+							role="button"
+							aria-label={translations.dragHandle || "Drag handle"}
+						>
+							&nbsp;
+						</div>
+					</th>
 				)}
 				{shouldHaveCheckboxColumn && (
 					<th className="neo-table-checkbox-th">

--- a/src/components/Table/TableComponents/TableHeader.tsx
+++ b/src/components/Table/TableComponents/TableHeader.tsx
@@ -129,10 +129,7 @@ export const TableHeader = <T extends Record<string, any>>({
 			<tr>
 				{canDrag && (
 					<th className="neo-table__dnd-th">
-						<div
-							role="button"
-							aria-label={translations.dragHandle || "Drag handle"}
-						>
+						<div role="button" aria-label={translations.dragHandle}>
 							&nbsp;
 						</div>
 					</th>
@@ -165,10 +162,15 @@ export const TableHeader = <T extends Record<string, any>>({
 											)
 										}
 									>
-										{allPageEnabledRowsSelected
-											? translations.clearPage
-											: translations.selectPage}{" "}
-										({pageEnabledRowCount})
+										{allPageEnabledRowsSelected ? (
+											<>
+												{translations.clearPage} ({pageEnabledRowCount})
+											</>
+										) : (
+											<>
+												{translations.selectPage} ({pageEnabledRowCount})
+											</>
+										)}
 									</MenuItem>
 
 									<MenuItem

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -54,23 +54,8 @@
 	align-items: flex-end;
 }
 
-/* had to use a td to avoid empty th a11y error */
-.neo-table thead td {
-	text-align: left;
-	color: var(--global-font-color);
-	vertical-align: middle;
-	background-color: var(--table-background-color);
-	letter-spacing: 0;
-	border-bottom: 1px solid var(--table-header-cell-border-color);
-	border-top: 1px solid var(--table-header-cell-border-color);
-	min-height: 44px;
-	padding: 12px 16px;
-	font-size: 14px;
-	font-weight: 600;
-	line-height: 20px;
-}
 
-.neo-table tr td.neo-table__dnd-th,
+.neo-table tr th.neo-table__dnd-th,
 .neo-table tr td.neo-table__dnd-td {
 	width: 16px;
 	display: table-cell;
@@ -78,12 +63,12 @@
 	padding: 6px 0px 0px 0px;
 }
 
-.neo-table tr td.neo-table__dnd-td,
+.neo-table tr th.neo-table__dnd-td,
 .neo-table tr.disabled td.neo-table__dnd-td * {
 	cursor: grab;
 }
 
-.neo-table tr td.neo-table__dnd-th>div,
+.neo-table tr th.neo-table__dnd-th>div,
 .neo-table tr td.neo-table__dnd-td>div {
 	width: 16px;
 	height: 16px;
@@ -91,7 +76,6 @@
 
 .neo-table tr td.neo-table__dnd-td>div {
 	display: none;
-	/* Hide by default */
 }
 
 .neo-table tbody tr:hover td.neo-table__dnd-td>div,
@@ -103,6 +87,12 @@
 	font-size: 16px;
 }
 
+.neo-table tr:hover th.neo-table__dnd-th,
+.neo-table tr:hover th.neo-table__dnd-th,
+.neo-table tr:hover th.neo-table-checkbox-th,
+.neo-table tr:hover th.neo-table-checkbox-th {
+	background-color: inherit;
+}
 
 .neo-table th.neo-table-checkbox-th {
 	padding: 0;

--- a/src/components/Table/helpers/default-data.ts
+++ b/src/components/Table/helpers/default-data.ts
@@ -28,6 +28,7 @@ export const translations: ITableTranslations = {
 		sortAscending: "A - Z",
 		sortDescending: "Z - A",
 		toggleSortBy: "Toggle SortBy",
+		dragHandle: "Drag Handle",
 	},
 	body: {
 		someItemsSelected: "Some items are selected.",

--- a/src/components/Table/types/TranslationTypes.ts
+++ b/src/components/Table/types/TranslationTypes.ts
@@ -45,6 +45,7 @@ export interface ITableHeaderTranslations {
 	sortAscending?: string;
 	sortDescending?: string;
 	toggleSortBy?: string;
+	dragHandle?: string;
 }
 
 export interface ITableTranslations {


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-457--neo-react-library-storybook.netlify.app/?path=/story/components-table--disabled-rows)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY (should be brief, one sentence if possible)


`@avaya-dux/dux-devs`:  
- try to change the background of dnd th cell along with checkbox th cell on tr:hover.
- switch back to use th for empty header cell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced accessibility with improved drag-and-drop functionality in table headers.
  - Added new translation support for drag handle in tables.

- **Bug Fixes**
  - Disabled excessive logging for better performance in table components.

- **Style**
  - Improved table styling for better alignment, padding, and cursor interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->