### PR TITLE
Table, tech debt // centralize shared logic and improve naming

### DIFF
--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -12,8 +12,8 @@ import {
 	FilledFields,
 	calculateAriaSortValue,
 	convertRowIdsArrayToObject,
-	toggleEnabledPageRows,
-	toggleEnabledTableRows,
+	setPageRowsSelected,
+	setTableRowsSelected,
 } from "./helpers";
 
 const {
@@ -915,9 +915,10 @@ describe("Table", () => {
 			});
 		});
 
-		describe("toggle row methos", () => {
-			it("`toggleEnabledTableRows` toggles the enabled state of all rows that are not disabled", () => {
+		describe("toggle row methods", () => {
+			it("`setTableRowsSelected` toggles the enabled state of all rows that are not disabled", () => {
 				const mocktoggleRowSelected = vi.fn();
+				const mockHandleRowToggled = vi.fn();
 				const mockInstance = {
 					rows: [
 						{
@@ -942,23 +943,27 @@ describe("Table", () => {
 					toggleRowSelected: mocktoggleRowSelected,
 				};
 
-				const falsyTest = toggleEnabledTableRows(mockInstance, false);
+				setTableRowsSelected(mockInstance, false, mockHandleRowToggled);
 
 				expect(mocktoggleRowSelected).toHaveBeenCalledTimes(2);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(1, false);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(3, false);
-				expect(falsyTest).toHaveLength(2);
+				expect(mockHandleRowToggled).toHaveBeenCalledTimes(1);
+				expect(mockHandleRowToggled).toHaveBeenCalledWith([]);
 
 				mocktoggleRowSelected.mockClear();
-				const truthyTest = toggleEnabledTableRows(mockInstance, true);
+				mockHandleRowToggled.mockClear();
+				setTableRowsSelected(mockInstance, true, mockHandleRowToggled);
 				expect(mocktoggleRowSelected).toHaveBeenCalledTimes(2);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(1, true);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(3, true);
-				expect(truthyTest).toHaveLength(2);
+				expect(mockHandleRowToggled).toHaveBeenCalledTimes(1);
+				expect(mockHandleRowToggled).toHaveBeenCalledWith([1, 3]);
 			});
 
-			it("`toggleEnabledPageRows` toggles the enabled state of all page rows that are not disabled", () => {
+			it("`setPageRowsSelected` toggles the enabled state of all page rows that are not disabled", () => {
 				const mocktoggleRowSelected = vi.fn();
+				const mockHandleRowToggled = vi.fn(); // TODO: use
 				const mockInstance = {
 					page: [
 						{
@@ -983,19 +988,22 @@ describe("Table", () => {
 					toggleRowSelected: mocktoggleRowSelected,
 				};
 
-				const falsyTest = toggleEnabledPageRows(mockInstance, false);
+				setPageRowsSelected(mockInstance, false, mockHandleRowToggled);
 
 				expect(mocktoggleRowSelected).toHaveBeenCalledTimes(2);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(1, false);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(3, false);
-				expect(falsyTest).toHaveLength(2);
+				expect(mockHandleRowToggled).toHaveBeenCalledTimes(1);
+				expect(mockHandleRowToggled).toHaveBeenCalledWith([]);
 
 				mocktoggleRowSelected.mockClear();
-				const truthyTest = toggleEnabledPageRows(mockInstance, true);
+				mockHandleRowToggled.mockClear();
+				setPageRowsSelected(mockInstance, true, mockHandleRowToggled);
 				expect(mocktoggleRowSelected).toHaveBeenCalledTimes(2);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(1, true);
 				expect(mocktoggleRowSelected).toHaveBeenCalledWith(3, true);
-				expect(truthyTest).toHaveLength(2);
+				expect(mockHandleRowToggled).toHaveBeenCalledTimes(1);
+				expect(mockHandleRowToggled).toHaveBeenCalledWith([1, 3]);
 			});
 		});
 	});

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -17,7 +17,7 @@ import type { TableBodyProps } from "../types";
 export const logger = log.getLogger("TableComponents/TableBody");
 logger.disableAll();
 
-import { toggleEnabledTableRows } from "../helpers";
+import { setTableRowsSelected } from "../helpers";
 
 import "./TableBody_shim.css";
 
@@ -76,6 +76,7 @@ export const TableBody: TableBodyComponentType = ({
 };
 
 const ClearSelectionRow: TableBodyComponentType = ({
+	handleRowToggled,
 	instance,
 	selectableRows,
 	translations,
@@ -124,7 +125,9 @@ const ClearSelectionRow: TableBodyComponentType = ({
 					<span>
 						{translations.allSelected} ({selectedRowCount})
 						<ClearButton
-							onClick={() => toggleEnabledTableRows(instance, false)}
+							onClick={() =>
+								setTableRowsSelected(instance, false, handleRowToggled)
+							}
 						>
 							{translations.clearSelection}
 						</ClearButton>
@@ -138,7 +141,11 @@ const ClearSelectionRow: TableBodyComponentType = ({
 				<>
 					<span>
 						{translations.pageSelected} ({selectedRowCount})
-						<ClearButton onClick={() => toggleEnabledTableRows(instance, true)}>
+						<ClearButton
+							onClick={() =>
+								setTableRowsSelected(instance, true, handleRowToggled)
+							}
+						>
 							{translations.selectAll}
 						</ClearButton>
 					</span>
@@ -150,7 +157,11 @@ const ClearSelectionRow: TableBodyComponentType = ({
 			<>
 				<span>
 					{translations.someItemsSelected} ({selectedRowCount})
-					<ClearButton onClick={() => toggleEnabledTableRows(instance, true)}>
+					<ClearButton
+						onClick={() =>
+							setTableRowsSelected(instance, true, handleRowToggled)
+						}
+					>
 						{translations.selectAll}
 					</ClearButton>
 				</span>
@@ -162,6 +173,7 @@ const ClearSelectionRow: TableBodyComponentType = ({
 		selectedRowCount,
 		allTableEnabledRowsAreSelected,
 		allPageEnabledRowsSelected,
+		handleRowToggled,
 	]);
 
 	// if no rows are selected, return

--- a/src/components/Table/TableComponents/TableHeader.tsx
+++ b/src/components/Table/TableComponents/TableHeader.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useCallback, useContext, useMemo } from "react";
+import { type KeyboardEvent, useContext, useMemo } from "react";
 
 import { Checkbox } from "components/Checkbox";
 import { Icon } from "components/Icon";
@@ -9,8 +9,8 @@ import { type IconNamesType, Keys } from "utils";
 import {
 	FilterContext,
 	calculateAriaSortValue,
-	toggleEnabledPageRows,
-	toggleEnabledTableRows,
+	setPageRowsSelected,
+	setTableRowsSelected,
 } from "../helpers";
 import type { TableHeaderProps } from "../types";
 
@@ -68,8 +68,9 @@ export const TableHeader = <T extends Record<string, any>>({
 	const [tableEnabledRowCount, allTableEnabledRowsAreSelected] = useMemo(() => {
 		const enabledRows = rows.filter((row) => !row.original.disabled);
 		const enabledRowCount = enabledRows.length;
-		const rowsSelectedMemo =
-			enabledRowCount && enabledRows.every((row) => selectedRowIds[row.id]);
+		const rowsSelectedMemo = !!(
+			enabledRowCount && enabledRows.every((row) => selectedRowIds[row.id])
+		);
 
 		return [enabledRowCount, rowsSelectedMemo];
 	}, [rows, selectedRowIds]);
@@ -88,42 +89,6 @@ export const TableHeader = <T extends Record<string, any>>({
 				: "mixed";
 	}, [allPageEnabledRowsSelected, allPageRowsDeselected]);
 
-	const toggleAllRows = useCallback(() => {
-		const toggledIds = toggleEnabledTableRows(
-			instance,
-			!allTableEnabledRowsAreSelected,
-		);
-
-		if (handleRowToggled) {
-			const shouldSelectAll = [false, "mixed"].includes(checkboxCheckedValue);
-
-			handleRowToggled(shouldSelectAll ? toggledIds : []);
-		}
-	}, [
-		instance,
-		allTableEnabledRowsAreSelected,
-		handleRowToggled,
-		checkboxCheckedValue,
-	]);
-
-	const togglePageRows = useCallback(() => {
-		const toggledIds = toggleEnabledPageRows(
-			instance,
-			!allPageEnabledRowsSelected,
-		);
-
-		if (handleRowToggled) {
-			const shouldSelectAll = [false, "mixed"].includes(checkboxCheckedValue);
-
-			handleRowToggled(shouldSelectAll ? toggledIds : []);
-		}
-	}, [
-		instance,
-		allPageEnabledRowsSelected,
-		handleRowToggled,
-		checkboxCheckedValue,
-	]);
-
 	return (
 		<thead>
 			<tr>
@@ -141,7 +106,13 @@ export const TableHeader = <T extends Record<string, any>>({
 								<Checkbox
 									checked={checkboxCheckedValue}
 									aria-label={translations.selectPage}
-									onChange={togglePageRows}
+									onChange={() =>
+										setPageRowsSelected(
+											instance,
+											!allPageEnabledRowsSelected,
+											handleRowToggled,
+										)
+									}
 									value="all"
 								/>
 
@@ -156,9 +127,10 @@ export const TableHeader = <T extends Record<string, any>>({
 								>
 									<MenuItem
 										onClick={() =>
-											toggleEnabledPageRows(
+											setPageRowsSelected(
 												instance,
 												!allPageEnabledRowsSelected,
+												handleRowToggled,
 											)
 										}
 									>
@@ -175,7 +147,11 @@ export const TableHeader = <T extends Record<string, any>>({
 
 									<MenuItem
 										onClick={() => {
-											toggleAllRows();
+											setTableRowsSelected(
+												instance,
+												!allTableEnabledRowsAreSelected,
+												handleRowToggled,
+											);
 										}}
 									>
 										{allTableEnabledRowsAreSelected ? (

--- a/src/components/Table/helpers/helpers.ts
+++ b/src/components/Table/helpers/helpers.ts
@@ -42,11 +42,13 @@ export const convertRowIdsArrayToObject = (rowIds: string[]) => {
  * Sets all table rows to selected or unselected based on the `selected` parameter and return toggled row ids.
  * @param instance - TableInstance
  * @param selected - boolean, whether to select or unselect the rows.
- * @returns string[], the ids of the toggled rows.
+ * @param handleRowToggled - (rowIds: string[]) => void, the user-defined callback
+ * @returns void
  */
-export const toggleEnabledTableRows = <T extends Record<string, unknown>>(
+export const setTableRowsSelected = <T extends Record<string, unknown>>(
 	instance: TableInstance<T>,
 	selected: boolean,
+	handleRowToggled?: (rowIds: string[]) => void,
 ) => {
 	const { rows, toggleRowSelected } = instance;
 
@@ -55,18 +57,22 @@ export const toggleEnabledTableRows = <T extends Record<string, unknown>>(
 		.map((row) => row.id);
 	enabledTableRowsIds.forEach((id) => toggleRowSelected(id, selected));
 
-	return enabledTableRowsIds;
+	if (handleRowToggled) {
+		handleRowToggled(selected ? enabledTableRowsIds : []);
+	}
 };
 
 /**
  * Sets all page rows to selected or unselected based on the `selected` parameter and return toggled row ids.
  * @param instance - TableInstance
  * @param selected - boolean, whether to select or unselect the rows.
- * @returns string[], the ids of the toggled rows.
+ * @param handleRowToggled - (rowIds: string[]) => void, the user-defined callback
+ * @returns void
  */
-export const toggleEnabledPageRows = <T extends Record<string, unknown>>(
+export const setPageRowsSelected = <T extends Record<string, unknown>>(
 	instance: TableInstance<T>,
 	selected: boolean,
+	handleRowToggled: (rowIds: string[]) => void,
 ) => {
 	const { page, toggleRowSelected } = instance;
 
@@ -75,5 +81,7 @@ export const toggleEnabledPageRows = <T extends Record<string, unknown>>(
 		.map((row) => row.id);
 	enabledPageRowsIds.forEach((id) => toggleRowSelected(id, selected));
 
-	return enabledPageRowsIds;
+	if (handleRowToggled) {
+		handleRowToggled(selected ? enabledPageRowsIds : []);
+	}
 };


### PR DESCRIPTION
[Link to updated Editable Table story](https://deploy-preview-460--neo-react-library-storybook.netlify.app/?path=/story/components-table--editable-data)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`


`@avaya-dux/dux-devs`: This centralizes some duplicated code and improves the naming for those shared functions. 

- centralize the functions that set the "clicked"/"selected" status for table rows
- rename: `toggleEnabledTableRows` -> `setTableRowsSelected` ("toggle" to "set")
- rename: `toggleEnabledPageRows` -> `setPageRowsSelected` ("toggle" to "set")
- add `handleRowToggled` to shared functions (user passed handler)
- updated tests to include `handleRowToggled` being added to the methods



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed functions to improve readability and consistency: 
    - `toggleEnabledTableRows` to `setTableRowsSelected`
    - `toggleEnabledPageRows` to `setPageRowsSelected`
- **New Features**
  - Added `handleRowToggled` parameter for custom row selection handling.
- **Tests**
  - Updated test cases to reflect function renaming and new mock functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->