### PR TITLE
NEO-2312: Fixing Table scenarios and adding new story

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.32",
+	"version": "1.1.33",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/IconButton/IconButton_shim.css
+++ b/src/components/IconButton/IconButton_shim.css
@@ -1,8 +1,19 @@
-.neo-btn.neo-icon-btn {
+.neo-btn.neo-badge::after {
+	right: 5px;
+	top: 5px;
+}
+
+.neo-table td .neo-btn.neo-btn-square,
+.neo-table tr:focus-within:not([class*="disabled"]) td .neo-btn.neo-btn-square,
+.neo-table tr:hover:not([class*="disabled"]) td .neo-btn.neo-btn-square {
 	display: flex;
 }
 
-.neo-btn.neo-badge::after {
-	right: 7px;
-	top: 4px;
+.neo-table td span[class*=neo-icon-state--large]::before {
+	font-size: 32px;
+}
+
+.neo-table td .neo-btn.neo-badge::after {
+	right: 6px;
+	top: 11px;
 }

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -5,6 +5,7 @@ import type { Column, ColumnInstance } from "react-table";
 import {
 	Chip,
 	Icon,
+	IconButton,
 	List,
 	ListItem,
 	Menu,
@@ -94,6 +95,29 @@ export const MoreActionsMenu = () => (
 							</MenuItem>
 						</Menu>
 					</Tooltip>
+				),
+			},
+		]}
+		data={[...FilledFields.data]}
+	/>
+);
+
+export const WithIconButton = () => (
+	<Table
+		caption="Last column has an IconButton."
+		columns={[
+			...FilledFields.columns,
+			{
+				Header: "Add Note",
+				Cell: () => (
+					<IconButton
+						shape="square"
+						icon="posts"
+						iconSize="lg"
+						variant="tertiary"
+						badge="7"
+						aria-label="Icon button"
+					/>
 				),
 			},
 		]}


### PR DESCRIPTION
[IconButton inside Table Cell](https://deploy-preview-462--neo-react-library-storybook.netlify.app/?path=/story/components-table--with-icon-button)

[Standalone IconButton with Badge](https://deploy-preview-462--neo-react-library-storybook.netlify.app/?path=/story/components-iconbutton--with-badge)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged `@avaya-dux/dux-devs`

This PR fixes rendering issues when a ButtonIcon component is inside a Neo Table cell. 

`@avaya-dux/dux-design`: Nothing new to review since you last reviewed it.

`@avaya-dux/dux-devs`: css code has increased specificity to fix Table scenarios. Also added new Table story to showcase scenario.

- IconButton inside Table cell should render properly
- Stand alone IconButtons should also render as expected.

<img width="737" alt="image" src="https://github.com/user-attachments/assets/027099d0-73ed-4e82-a297-d75237d16c10">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an "Add Note" icon button within the table component to enhance interactivity.
  
- **Style**
  - Improved styling and positioning of badges and icons within table cells for a more polished appearance.

- **Chores**
  - Updated the `@avaya/neo-react` package version from `1.1.32` to `1.1.33`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->