### PR TITLE
NEO-2312: IconButton inside Table fix part 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.32",
+	"version": "1.1.33",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.34",
+	"version": "1.1.35",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -62,6 +62,8 @@ export const IconButton = forwardRef(
 			);
 		}
 
+		const iconBtnClass = "neo-icon-btn";
+
 		const displaySpinner = useMemo(() => showSpinner(animation), [animation]);
 
 		const buttonClasses = useMemo(() => {
@@ -72,6 +74,7 @@ export const IconButton = forwardRef(
 
 			const result = [
 				rootBtnClass,
+				iconBtnClass,
 				sizeOrShapeClass,
 				getSizeClass(size),
 				...getVariantClasses(shape, variant, status),

--- a/src/components/IconButton/IconButton_shim.css
+++ b/src/components/IconButton/IconButton_shim.css
@@ -1,19 +1,19 @@
-.neo-btn.neo-badge::after {
+.neo-btn.neo-icon-btn.neo-badge::after {
 	right: 5px;
 	top: 5px;
 }
 
-.neo-table td .neo-btn.neo-btn-square,
-.neo-table tr:focus-within:not([class*="disabled"]) td .neo-btn.neo-btn-square,
-.neo-table tr:hover:not([class*="disabled"]) td .neo-btn.neo-btn-square {
+.neo-table td .neo-btn.neo-btn-square.neo-icon-btn,
+.neo-table tr:focus-within:not([class*="disabled"]) td .neo-btn.neo-btn-square.neo-icon-btn,
+.neo-table tr:hover:not([class*="disabled"]) td .neo-btn.neo-btn-square.neo-icon-btn {
 	display: flex;
 }
 
-.neo-table td span[class*=neo-icon-state--large]::before {
+.neo-table td .neo-icon-btn span[class*=neo-icon-state--large]::before {
 	font-size: 32px;
 }
 
-.neo-table td .neo-btn.neo-badge::after {
+.neo-table td .neo-btn.neo-icon-btn.neo-badge::after {
 	right: 6px;
 	top: 11px;
 }

--- a/src/components/IconButton/IconButton_shim.css
+++ b/src/components/IconButton/IconButton_shim.css
@@ -1,8 +1,19 @@
-.neo-btn.neo-icon-btn {
+.neo-btn.neo-badge::after {
+	right: 5px;
+	top: 5px;
+}
+
+.neo-table td .neo-btn.neo-btn-square,
+.neo-table tr:focus-within:not([class*="disabled"]) td .neo-btn.neo-btn-square,
+.neo-table tr:hover:not([class*="disabled"]) td .neo-btn.neo-btn-square {
 	display: flex;
 }
 
-.neo-btn.neo-badge::after {
-	right: 7px;
-	top: 4px;
+.neo-table td span[class*=neo-icon-state--large]::before {
+	font-size: 32px;
+}
+
+.neo-table td .neo-btn.neo-badge::after {
+	right: 6px;
+	top: 11px;
 }

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -203,63 +203,63 @@ describe("ListSection: ", () => {
 		it("should match snapshots", () => {
 			const { container } = renderResult;
 			expect(container).toMatchInlineSnapshot(`
-        <div>
-          <ul
-            class="neo-group-list--actions"
-          >
-            <li
-              class="neo-group-list--actions__item neo-group-list--actions__item--clickable"
-            >
-              <div
-                class="neo-group-list__actions--left"
-              >
-                <span
-                  aria-label="chat icon"
-                  class="neo-icon-chat neo-icon--small"
-                  data-testid="neo-icon-chat"
-                  id="icon-chat"
-                  role="img"
-                />
-                First item with chat icon and transfer call button
-              </div>
-              <div
-                class="neo-group-list__actions--right"
-              >
-                <button
-                  aria-label="transfer call"
-                  class="neo-btn neo-btn-circle neo-btn--default neo-btn-tertiary neo-btn-tertiary--default neo-btn-circle-tertiary--default"
-                  data-badge=""
-                  data-testid="neo-button-transfer"
-                  id="btn-transfer-call"
-                >
-                  <span
-                    class="neo-icon-call-transfer"
-                  />
-                </button>
-              </div>
-            </li>
-            <li
-              class="neo-group-list--actions__item neo-group-list--actions__item--clickable"
-            >
-              <div
-                class="neo-group-list__actions--left"
-              >
-                <span
-                  aria-label="star icon"
-                  class="neo-icon-star neo-icon--small"
-                  data-testid="neo-icon-star"
-                  id="icon-star"
-                  role="img"
-                />
-                Second item with star icon
-              </div>
-              <div
-                class="neo-group-list__actions--right"
-              />
-            </li>
-          </ul>
-        </div>
-      `);
+				<div>
+				  <ul
+				    class="neo-group-list--actions"
+				  >
+				    <li
+				      class="neo-group-list--actions__item neo-group-list--actions__item--clickable"
+				    >
+				      <div
+				        class="neo-group-list__actions--left"
+				      >
+				        <span
+				          aria-label="chat icon"
+				          class="neo-icon-chat neo-icon--small"
+				          data-testid="neo-icon-chat"
+				          id="icon-chat"
+				          role="img"
+				        />
+				        First item with chat icon and transfer call button
+				      </div>
+				      <div
+				        class="neo-group-list__actions--right"
+				      >
+				        <button
+				          aria-label="transfer call"
+				          class="neo-btn neo-icon-btn neo-btn-circle neo-btn--default neo-btn-tertiary neo-btn-tertiary--default neo-btn-circle-tertiary--default"
+				          data-badge=""
+				          data-testid="neo-button-transfer"
+				          id="btn-transfer-call"
+				        >
+				          <span
+				            class="neo-icon-call-transfer"
+				          />
+				        </button>
+				      </div>
+				    </li>
+				    <li
+				      class="neo-group-list--actions__item neo-group-list--actions__item--clickable"
+				    >
+				      <div
+				        class="neo-group-list__actions--left"
+				      >
+				        <span
+				          aria-label="star icon"
+				          class="neo-icon-star neo-icon--small"
+				          data-testid="neo-icon-star"
+				          id="icon-star"
+				          role="img"
+				        />
+				        Second item with star icon
+				      </div>
+				      <div
+				        class="neo-group-list__actions--right"
+				      />
+				    </li>
+				  </ul>
+				</div>
+			`);
 		});
 
 		it("passes basic axe compliance", async () => {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -5,6 +5,7 @@ import type { Column, ColumnInstance } from "react-table";
 import {
 	Chip,
 	Icon,
+	IconButton,
 	List,
 	ListItem,
 	Menu,
@@ -94,6 +95,29 @@ export const MoreActionsMenu = () => (
 							</MenuItem>
 						</Menu>
 					</Tooltip>
+				),
+			},
+		]}
+		data={[...FilledFields.data]}
+	/>
+);
+
+export const WithIconButton = () => (
+	<Table
+		caption="Last column has an IconButton."
+		columns={[
+			...FilledFields.columns,
+			{
+				Header: "Add Note",
+				Cell: () => (
+					<IconButton
+						shape="square"
+						icon="posts"
+						iconSize="lg"
+						variant="tertiary"
+						badge="7"
+						aria-label="Icon button"
+					/>
 				),
 			},
 		]}


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-466--neo-react-library-storybook.netlify.app/?path=/story/components-table--with-icon-button)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] tagged `@avaya-dux/dux-devs`

This should complete the fix.

`@avaya-dux/dux-design`: Already has been reviewed. No visual changes to verify. 


`@avaya-dux/dux-devs`: Increased css selectors specificity to avoid conflicts caused by order of css loading.

- New selectors have now greater specificity values. The previous ones had the same specificity.
- Added a new "neo-icon-btn" class to accomplish this.
- Updated markup snapshot for test

<img width="533" alt="image" src="https://github.com/user-attachments/assets/876c204d-f7b6-4c33-85ef-6592a34d4876">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced styling capabilities for icon buttons through the addition of the `neo-icon-btn` class.
	- Updated button styles to improve visual representation and functionality, particularly for buttons using icons.

- **Bug Fixes**
	- Refined the layout of button components for better visual alignment and user experience.

- **Chores**
	- Incremented version number of the `@avaya/neo-react` package from `1.1.34` to `1.1.35`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->