### PR TITLE
Select // do not show "clear" button when select is disabled

### DIFF
--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -232,18 +232,20 @@ export const MultiSelect = () => {
 					isOpen && "neo-multiselect-combo__header--expanded",
 				)}
 			>
-				{/* put button before span so that it gets tab order first */}
-				<button
-					aria-label="clear selections"
-					className={clsx(
-						"neo-input-edit__icon neo-icon-end",
-						"neo-multiselect-clear-icon-button",
-						selectedItems.length === 0 && "neo-display-none",
-					)}
-					type="button"
-					disabled={selectedItems.length === 0}
-					onClick={() => setSelectedItems([])}
-				/>
+				{!disabled && (
+					// put button before span so that it gets tab order first
+					<button
+						aria-label="clear selections"
+						className={clsx(
+							"neo-input-edit__icon neo-icon-end",
+							"neo-multiselect-clear-icon-button",
+							selectedItems.length === 0 && "neo-display-none",
+						)}
+						type="button"
+						disabled={disabled || selectedItems.length === 0}
+						onClick={() => setSelectedItems([])}
+					/>
+				)}
 				<span
 					ref={chipContainerRef}
 					key="multiselect-chip-container"

--- a/src/components/Select/InternalComponents/MultiSelect.tsx
+++ b/src/components/Select/InternalComponents/MultiSelect.tsx
@@ -242,7 +242,7 @@ export const MultiSelect = () => {
 							selectedItems.length === 0 && "neo-display-none",
 						)}
 						type="button"
-						disabled={disabled || selectedItems.length === 0}
+						disabled={selectedItems.length === 0}
 						onClick={() => setSelectedItems([])}
 					/>
 				)}

--- a/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/MultiSelectSearchable.tsx
@@ -124,17 +124,21 @@ export const MultiSelectSearchable = () => {
 
 					{selectedItemsAsChips}
 				</span>
-				<button
-					aria-label="clear selections"
-					className={clsx(
-						"neo-input-edit__icon neo-icon-end",
-						"neo-multiselect-clear-icon-button",
-						selectedItems.length === 0 && "neo-display-none",
-					)}
-					type="button"
-					disabled={selectedItems.length === 0}
-					onClick={() => setSelectedItems([])}
-				/>
+
+				{!disabled && (
+					<button
+						aria-label="clear selections"
+						className={clsx(
+							"neo-input-edit__icon neo-icon-end",
+							"neo-multiselect-clear-icon-button",
+							selectedItems.length === 0 && "neo-display-none",
+						)}
+						type="button"
+						disabled={selectedItems.length === 0}
+						onClick={() => setSelectedItems([])}
+					/>
+				)}
+
 				<input
 					className="neo-display-none"
 					id={id}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -331,11 +331,13 @@ export const Creatable = () => {
 };
 
 export const Disabled = () => (
-	<Select label="I am disabled" disabled>
-		<SelectOption>Option 1</SelectOption>
-		<SelectOption disabled>Option 2</SelectOption>
-		<SelectOption>Option 3</SelectOption>
-		<SelectOption>Option 4</SelectOption>
+	<Select label="I am disabled" disabled multiple value={["3", "4"]}>
+		<SelectOption value="1">Option 1</SelectOption>
+		<SelectOption value="2" disabled>
+			Option 2
+		</SelectOption>
+		<SelectOption value="3">Option 3</SelectOption>
+		<SelectOption value="4">Option 4</SelectOption>
 	</Select>
 );
 

--- a/src/components/Select/Select.test.jsx
+++ b/src/components/Select/Select.test.jsx
@@ -82,6 +82,46 @@ describe("Select", () => {
 			expect(clearButton).toHaveClass("neo-multiselect-clear-icon-button");
 			expect(clearButton).toBeDisabled();
 		});
+
+		it("does not have a clear button when disabled, even if there are selections", () => {
+			render(
+				<Select multiple disabled label="not important" value={["3", "4"]}>
+					<SelectOption value="1">Option 1</SelectOption>
+					<SelectOption value="2" disabled>
+						Option 2
+					</SelectOption>
+					<SelectOption value="3">Option 3</SelectOption>
+					<SelectOption value="4">Option 4</SelectOption>
+				</Select>,
+			);
+
+			const buttonsMulti = screen.getAllByRole("button");
+			buttonsMulti.forEach((button) => {
+				expect(button).not.toHaveClass("neo-multiselect-clear-icon-button");
+			});
+
+			render(
+				<Select
+					multiple
+					searchable
+					disabled
+					label="not important"
+					value={["3", "4"]}
+				>
+					<SelectOption value="1">Option 1</SelectOption>
+					<SelectOption value="2" disabled>
+						Option 2
+					</SelectOption>
+					<SelectOption value="3">Option 3</SelectOption>
+					<SelectOption value="4">Option 4</SelectOption>
+				</Select>,
+			);
+
+			const buttonsMultiSearchable = screen.getAllByRole("button");
+			buttonsMultiSearchable.forEach((button) => {
+				expect(button).not.toHaveClass("neo-multiselect-clear-icon-button");
+			});
+		});
 	});
 
 	describe("Single Select, non-searchable", () => {


### PR DESCRIPTION
[Link to updated Select story](https://deploy-preview-468--neo-react-library-storybook.netlify.app/?path=/story/components-select--disabled)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

[Sanved pointed out](https://teams.microsoft.com/l/message/19:0c670e994bea49d3b3fd053761191c8c@thread.tacv2/1721639780196?tenantId=04a2636c-326d-48ff-93f8-709875bd3aa9&groupId=172efbe2-ae64-4652-8f08-de11e90b9230&parentMessageId=1721639780196&teamName=NEO%20Design%20System&channelName=Neo%20-%20Make%20New%20Requests&createdTime=1721639780196) that the Select's clear button is still usable when the Select is disabled. This hides the clear button when the Select is disabled.

`@avaya-dux/dux-devs`: code and functional check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `MultiSelect` and `MultiSelectSearchable` components to conditionally render the clear selections button based on the disabled state, improving usability.
	- Updated the `Select` component to support multiple selections even when disabled, enhancing functionality.
  
- **Bug Fixes**
	- Introduced tests to ensure the clear selections button is not displayed when the component is disabled, preventing user confusion.

- **Documentation**
	- Clarified the behavior of the `Select` component in its story, improving accessibility and usability insights for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->