### PR TITLE
NEO-2189  The dragged row now moves by one row at each key press

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
-import { arrayMove } from "@dnd-kit/sortable";
+import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import clsx from "clsx";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -282,7 +282,9 @@ export const Table = <T extends Record<string, any>>({
 	const sensors = useSensors(
 		useSensor(MouseSensor, {}),
 		useSensor(TouchSensor, {}),
-		useSensor(KeyboardSensor, {}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
 	);
 
 	function handleDragStart(event: DragStartEvent) {


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-469--neo-react-library-storybook.netlify.app/?path=/story/components-table--editable-data)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`


`@avaya-dux/dux-design`: per @matthewAvaya suggestion, changed keyboard movement from 25px default to one row per key press.

`@avaya-dux/dux-devs`:  minor change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved keyboard navigation for drag-and-drop operations within the Table component.
	- Enhanced accuracy in coordinate calculations for sortable items.

- **Bug Fixes**
	- Addressed issues with keyboard interactions to ensure a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->