### PR TITLE
init tabpanel index with active tab index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.36",
+	"version": "1.1.37",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Tab/Tabs.stories.tsx
+++ b/src/components/Tab/Tabs.stories.tsx
@@ -85,7 +85,7 @@ export const ControlledActiveTabStory = () => {
 				</Button>
 			</div>
 
-			<Tabs defaultIndex={activeTabIndex} onTabChange={onTabChange}>
+			<Tabs index={activeTabIndex} defaultIndex={0} onTabChange={onTabChange}>
 				<TabList>
 					<Tab id="tab1" disabled={disabledFlags[0]}>
 						Tab1

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -82,7 +82,7 @@ export const Tabs = ({
 		onTabChange?.(newActiveTabIndex);
 	};
 
-	const [activePanelIndex, setActivePanelIndex] = useState(defaultIndex);
+	const [activePanelIndex, setActivePanelIndex] = useState(activeTabIndex);
 
 	useEffect(() => {
 		onTabPanelChange?.(activePanelIndex);


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-472--neo-react-library-storybook.netlify.app/?path=/story/components-tab--controlled-active-tab-story)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY:  init tab panel index with tab index

`@avaya-dux/dux-devs`:  
- correct panel is shown as in "Disable|Enable Tabs" story


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more dynamic tab control in the `Tabs` component, enhancing responsiveness by managing the active tab through an external state.
  
- **Bug Fixes**
	- Updated the version of the `@avaya/neo-react` package, indicating potential bug fixes or improvements.
  
- **Documentation**
	- Revised prop documentation for the `Tabs` component to reflect the new `index` prop usage instead of `defaultIndex`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->