### PR TITLE
Select // do not allow whitespace or duplicate entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.1.38",
+	"version": "1.1.39",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Select/InternalComponents/OptionsWithEmptyMessageFallback.tsx
+++ b/src/components/Select/InternalComponents/OptionsWithEmptyMessageFallback.tsx
@@ -20,7 +20,7 @@ export const OptionsWithEmptyMessageFallback = () => {
 					/>
 				))
 			) : (
-				<InternalSelectOption disabled index={0} key="no-available-options">
+				<InternalSelectOption disabled index={-1} key="no-available-options">
 					{noOptionsMessage}
 				</InternalSelectOption>
 			)}

--- a/src/components/Select/Searchable.test.jsx
+++ b/src/components/Select/Searchable.test.jsx
@@ -276,7 +276,6 @@ describe("Select", () => {
 			expect(screen.getByText(secondOptionText)).toBeInTheDocument();
 		});
 
-		// cannot add whitespace-only, empty, or duplicate options
 		it("does not allow a user to create whitespace-only options, or duplicate existing options", async () => {
 			const newOptionText = "New Option";
 			render(

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -127,6 +127,7 @@ export const CollapsedNarrowMultiSelect = () => {
 		</Sheet>
 	);
 };
+
 export const Localized = () => {
 	const [lang, setLang] = useState("English");
 	const [currTranslations, setCurrTranslations] = useState(englishTrans);

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -198,7 +198,7 @@ const DownshiftWithComboboxMultipleSelectProps = (
 					creatable &&
 					trimmedValue !== "" &&
 					relatedOptions.length === 0 &&
-					!selectedItems.some((item) => item.value === trimmedValue);
+					selectedItems.every((item) => item.value !== trimmedValue);
 
 				if (allowCreate) {
 					const createdItem: SelectOptionProps = {


### PR DESCRIPTION
[Link to updated Select Createable story](https://deploy-preview-476--neo-react-library-storybook.netlify.app/?path=/story/components-select--creatable)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

Bhavesh pointed out that users can currently create whitespace-only and duplicate entries. This fixes those issues by utilizing `.trim()` to check for whitespace, and then also looking at the Select components `selectedItems` context value to see what values currently exist. 

`@avaya-dux/dux-devs`: check code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced input handling in the Select component to ignore whitespace for option creation and filtering.
	- Added test coverage for preventing whitespace-only and duplicate options in searchable dropdowns.

- **Bug Fixes**
	- Adjusted index handling for empty option scenarios to improve clarity in component behavior.

- **Style**
	- Minor cosmetic changes made to the Select component for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->