### PR TITLE
point users to our MS Teams channel

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -306,8 +306,8 @@ export const Creatable = () => {
 
 				<p style={{ paddingBottom: 10 }}>
 					Please reach out to us{" "}
-					<a href="https://github.com/avaya-dux/neo-react-library/issues/new">
-						via our GitHub page
+					<a href="https://teams.microsoft.com/l/channel/19%3A0c670e994bea49d3b3fd053761191c8c%40thread.tacv2/Neo%20-%20Make%20New%20Requests?groupId=172efbe2-ae64-4652-8f08-de11e90b9230&tenantId=04a2636c-326d-48ff-93f8-709875bd3aa9">
+						via our MS Teams channel
 					</a>{" "}
 					if you have any questions or concerns.
 				</p>
@@ -383,8 +383,8 @@ export const RequiredInForm = () => {
 
 				<p style={{ paddingBottom: 10 }}>
 					We&apos;ve created this example, but please reach out to us{" "}
-					<a href="https://github.com/avaya-dux/neo-react-library/issues/new">
-						via our GitHub page
+					<a href="https://teams.microsoft.com/l/channel/19%3A0c670e994bea49d3b3fd053761191c8c%40thread.tacv2/Neo%20-%20Make%20New%20Requests?groupId=172efbe2-ae64-4652-8f08-de11e90b9230&tenantId=04a2636c-326d-48ff-93f8-709875bd3aa9">
+						via our MS Teams channel
 					</a>{" "}
 					if you have any questions or concerns.
 				</p>


### PR DESCRIPTION
point users to our MS Teams channel, not our GitHub Issues page

Affected stories: [Creatable](https://deploy-preview-477--neo-react-library-storybook.netlify.app/?path=/story/components-select--creatable), and [Required in Form](https://deploy-preview-477--neo-react-library-storybook.netlify.app/?path=/story/components-select--required-in-form)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated support links in the `Creatable` and `RequiredInForm` components to direct users to a Microsoft Teams channel for inquiries and feedback.
	- Enhanced clarity by specifying "MS Teams channel" in the accompanying text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->