### PR TITLE
fix colspan when table is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -559,14 +559,39 @@ export const EditableData = () => {
 	);
 };
 
-export const EmptyDataSet = () => (
-	<Table
-		caption="Storybook Empty Date Set Table Example"
-		columns={FilledFields.columns}
-		data={[]}
-		handleRefresh={() => undefined}
-	/>
-);
+export const EmptyDataSet = () => {
+	const [draggable, setDraggable] = useState(false);
+	const [multiple, setMultiple] = useState(false);
+
+	return (
+		<div>
+			<Table
+				caption="Storybook Empty Date Set Table Example"
+				columns={FilledFields.columns}
+				data={[]}
+				handleRefresh={() => undefined}
+				draggableRows={draggable}
+				selectableRows={multiple ? "multiple" : "none"}
+				customActionsNode={
+					<section>
+						<Switch
+							checked={draggable}
+							onChange={(_e, updatedChecked) => setDraggable(updatedChecked)}
+						>
+							Draggable Switch
+						</Switch>
+						<Switch
+							checked={multiple}
+							onChange={(_e, updatedChecked) => setMultiple(updatedChecked)}
+						>
+							Multiple Switch
+						</Switch>
+					</section>
+				}
+			/>
+		</div>
+	);
+};
 
 export const PaginationPushedDown = () => (
 	<Table

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -44,13 +44,18 @@ export const TableBody: TableBodyComponentType = ({
 	translations,
 }) => {
 	const { getTableBodyProps, headers, page, rows } = instance;
-
+	const shouldHaveCheckboxColumn = selectableRows !== "none";
+	const { draggableRows } = useContext(FilterContext);
+	const numberOfColumns =
+		headers.length +
+		(shouldHaveCheckboxColumn ? 1 : 0) +
+		(draggableRows ? 1 : 0);
 	return (
 		<tbody {...getTableBodyProps()}>
 			<SortableContext items={rows} strategy={verticalListSortingStrategy}>
 				{page.length === 0 ? (
 					<tr>
-						<td colSpan={headers.length}>{translations.noDataAvailable}</td>
+						<td colSpan={numberOfColumns}>{translations.noDataAvailable}</td>
 					</tr>
 				) : (
 					<>


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-488--neo-react-library-storybook.netlify.app/?path=/story/components-table--empty-data-set)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [ ] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY (should be brief, one sentence if possible)

`@avaya-dux/dux-devs`:  account for draggable and checkbox columns when setting empty row colspan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `EmptyDataSet` component to support draggable and selectable table rows, improving interactivity and user experience.
  - Introduced dynamic column management in the `TableBody` component to accommodate checkbox columns based on user selections.

- **Chores**
  - Updated the version number of the `@avaya/neo-react` package to `1.2.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->