### PR TITLE
NEO-2123:  Refactor Table filter as Drawer

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -197,6 +197,7 @@ export const ServerSidePagination = () => {
 			pageCount={pageCount}
 			handlePageChange={fetchData}
 			itemsPerPageOptions={[5, 10, 20, 50]}
+			allowColumnFilter
 			caption="Server Side Pagination Example"
 			summary="This table will load one page at a time."
 		/>

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -729,12 +729,7 @@ describe("Table", () => {
 			);
 			expect(firstColumnSortButton).toBeVisible();
 
-			expect(getByRole("dialog")).not.toHaveClass(
-				"sheet-horizontal-slide-in-shim",
-			);
-			expect(getByRole("dialog")).not.toHaveClass(
-				"sheet-horizontal-slide-out-shim",
-			);
+			expect(getByRole("dialog")).not.toHaveClass("neo-drawer neo-drawer--isOpen");
 
 			await user.click(firstColumnSortButton);
 
@@ -742,16 +737,16 @@ describe("Table", () => {
 			expect(menuItems).toHaveLength(4);
 			await user.click(queryAllByRole("menuitem")[3]);
 
-			expect(getByRole("dialog")).toHaveClass("sheet-horizontal-slide-in-shim");
-			expect(getByRole("dialog")).not.toHaveClass(
-				"sheet-horizontal-slide-out-shim",
-			);
+			expect(getByRole("dialog")).toHaveClass("neo-drawer neo-drawer--isOpen");
 
 			const nameCheckbox = getByLabelText(FilledFields.columns[0].Header);
 			expect(nameCheckbox).toBeChecked();
 
 			await user.click(nameCheckbox);
 			expect(nameCheckbox).not.toBeChecked();
+
+			const applyButton = getByLabelText("Apply");
+			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
 		});
 
@@ -770,25 +765,20 @@ describe("Table", () => {
 				`button[aria-label="${FilledFields.translations.toolbar.filterColumns}"]`,
 			);
 
-			expect(getByRole("dialog")).not.toHaveClass(
-				"sheet-horizontal-slide-in-shim",
-			);
-			expect(getByRole("dialog")).not.toHaveClass(
-				"sheet-horizontal-slide-out-shim",
-			);
+			expect(getByRole("dialog")).not.toHaveClass("neo-drawer neo-drawer--isOpen");
 
 			await user.click(columnFilterButton);
 
-			expect(getByRole("dialog")).toHaveClass("sheet-horizontal-slide-in-shim");
-			expect(getByRole("dialog")).not.toHaveClass(
-				"sheet-horizontal-slide-out-shim",
-			);
+			expect(getByRole("dialog")).toHaveClass("neo-drawer neo-drawer--isOpen");
 
 			const nameCheckbox = getByLabelText(FilledFields.columns[0].Header);
 			expect(nameCheckbox).toBeChecked();
 
 			await user.click(nameCheckbox);
 			expect(nameCheckbox).not.toBeChecked();
+
+			const applyButton = getByLabelText("Apply");
+			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
 		});
 	});

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -747,7 +747,7 @@ describe("Table", () => {
 			await user.click(nameCheckbox);
 			expect(nameCheckbox).not.toBeChecked();
 
-			const applyButton = getByLabelText("Apply");
+			const applyButton = getByLabelText(FilledFields.translations.toolbar.apply);
 			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
 		});
@@ -781,7 +781,7 @@ describe("Table", () => {
 			await user.click(nameCheckbox);
 			expect(nameCheckbox).not.toBeChecked();
 
-			const applyButton = getByLabelText("Apply");
+			const applyButton = getByLabelText(FilledFields.translations.toolbar.apply);
 			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
 		});

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -729,7 +729,9 @@ describe("Table", () => {
 			);
 			expect(firstColumnSortButton).toBeVisible();
 
-			expect(getByRole("dialog")).not.toHaveClass("neo-drawer neo-drawer--isOpen");
+			expect(getByRole("dialog")).not.toHaveClass(
+				"neo-drawer neo-drawer--isOpen",
+			);
 
 			await user.click(firstColumnSortButton);
 
@@ -765,7 +767,9 @@ describe("Table", () => {
 				`button[aria-label="${FilledFields.translations.toolbar.filterColumns}"]`,
 			);
 
-			expect(getByRole("dialog")).not.toHaveClass("neo-drawer neo-drawer--isOpen");
+			expect(getByRole("dialog")).not.toHaveClass(
+				"neo-drawer neo-drawer--isOpen",
+			);
 
 			await user.click(columnFilterButton);
 

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -747,7 +747,9 @@ describe("Table", () => {
 			await user.click(nameCheckbox);
 			expect(nameCheckbox).not.toBeChecked();
 
-			const applyButton = getByLabelText(FilledFields.translations.toolbar.apply);
+			const applyButton = getByLabelText(
+				FilledFields.translations.toolbar.apply,
+			);
 			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
 		});
@@ -781,7 +783,9 @@ describe("Table", () => {
 			await user.click(nameCheckbox);
 			expect(nameCheckbox).not.toBeChecked();
 
-			const applyButton = getByLabelText(FilledFields.translations.toolbar.apply);
+			const applyButton = getByLabelText(
+				FilledFields.translations.toolbar.apply,
+			);
 			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
 		});

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -18,7 +18,6 @@ export const TableFilter = <T extends Record<string, any>>({
 }: TableFilterProps<T>) => {
 	// translations
 	const apply = translations.apply || defaultTranslations.toolbar.apply;
-	const clear = translations.clear || defaultTranslations.toolbar.clear;
 	const close =
 		translations.close || defaultTranslations.toolbar.close || "Close";
 	const filterColumns =
@@ -41,14 +40,6 @@ export const TableFilter = <T extends Record<string, any>>({
 			key="table-filter-apply-button"
 		>
 			{apply}
-		</Button>,
-		<Button
-			aria-label={clear}
-			variant="secondary"
-			onClick={() => setHiddenColumns([])}
-			key="table-filter-reset-icon-button"
-		>
-			{clear}
 		</Button>,
 		<Button
 			aria-label={close}
@@ -78,11 +69,14 @@ export const TableFilter = <T extends Record<string, any>>({
 				actions={actionButtons}
 			>
 				<section>
-					{allColumns.map((column) => (
-						<Checkbox key={column.id} {...column.getToggleHiddenProps()}>
-							{column.Header}
-						</Checkbox>
-					))}
+					{allColumns.map((column) => {
+				console.log(column.getToggleHiddenProps);
+				return (
+					<Checkbox key={column.id} {...column.getToggleHiddenProps()}>
+						{column.Header}
+					</Checkbox>
+				);
+			})}
 				</section>
 			</Drawer>
 		</>

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -1,5 +1,5 @@
-import { useContext } from "react";
-import type { TableInstance } from "react-table";
+import { useCallback, useContext, useState } from "react";
+import type { IdType, TableInstance } from "react-table";
 
 import { Button, Checkbox, Drawer, IconButton } from "components";
 import { FilterContext, translations as defaultTranslations } from "../helpers";
@@ -50,6 +50,19 @@ export const TableFilter = <T extends Record<string, any>>({
 		</Button>,
 	];
 
+	const [visibleCols, setVisibleCols] = useState(visibleColumns);
+
+	const handleColumnVisibilityChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		console.log("column checked: ", e.target);
+		const newCols:IdType<T>[]= [];
+
+		visibleCols.map((col)=> {
+			if (col.id !== "recordingName")
+				newCols.push(col.id);
+		})
+		setHiddenColumns(newCols);
+	}, []);
+
 	return (
 		<>
 			<IconButton
@@ -71,8 +84,15 @@ export const TableFilter = <T extends Record<string, any>>({
 					{allColumns.map((column) => {
 						const colProps = { ...column.getToggleHiddenProps() };
 						console.log({colProps});
+						console.log("column.id: ", column.id);
 						return (
-							<Checkbox key={column.id} {...column.getToggleHiddenProps()}>
+							<Checkbox
+								key={column.id}
+								id={column.id}
+								checked={colProps.checked}
+								title={colProps.title}
+								onChange={handleColumnVisibilityChange}
+							>
 								{column.Header}
 							</Checkbox>
 						);

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useContext, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import type { IdType, TableInstance } from "react-table";
 
 import {

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -42,15 +42,16 @@ export const TableFilter = <T extends Record<string, any>>({
 	const { filterSheetVisible, toggleFilterSheetVisible } =
 		useContext(FilterContext);
 
-	// newAllColumns is a temporary array that is used while the filter Drawer is open.
-	const [newAllColumns, setNewAllColumns] = useState<FilterColumns[]>([]);
+	// filteredColumns is a temporary array that is used while the filter Drawer is open.
+	const [filteredColumns, setNewAllColumns] = useState<FilterColumns[]>([]);
+	const [applyEnabled, setApplyEnabled] = useState<boolean>(false);
 
 	const handleColumnVisibilityChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			const { checked, value } = e.target;
 
-			//Update newAllColumns array checked value
-			const nextColumns = newAllColumns.map((col) => {
+			//Update filteredColumns array checked value
+			const nextColumns = filteredColumns.map((col) => {
 				return {
 					id: col.id,
 					hdr: col.hdr,
@@ -59,8 +60,9 @@ export const TableFilter = <T extends Record<string, any>>({
 			});
 
 			setNewAllColumns(nextColumns);
+			setApplyEnabled(true);
 		},
-		[newAllColumns],
+		[filteredColumns],
 	);
 
 	useEffect(() => {
@@ -79,16 +81,17 @@ export const TableFilter = <T extends Record<string, any>>({
 
 	const handleApplyChanges = useCallback(() => {
 		const newHiddenColIds: IdType<T>[] = [];
-		newAllColumns.forEach((col) => {
+		filteredColumns.forEach((col) => {
 			if (!col.checked) {
 				newHiddenColIds.push(col.id);
 			}
 		});
 
 		setHiddenColumns(newHiddenColIds); // Using Table api to hide unchecked columns.
+		setApplyEnabled(false);
 		toggleFilterSheetVisible();
 	}, [
-		newAllColumns,
+		filteredColumns,
 		setHiddenColumns,
 		toggleFilterSheetVisible,
 	]);
@@ -97,6 +100,7 @@ export const TableFilter = <T extends Record<string, any>>({
 		<Button
 			aria-label={apply}
 			onClick={handleApplyChanges}
+			disabled={!applyEnabled}
 			key="table-filter-apply-button"
 		>
 			{apply}
@@ -134,7 +138,7 @@ export const TableFilter = <T extends Record<string, any>>({
 						aria-labelledby="column-filter"
 						onChange={handleColumnVisibilityChange}
 					>
-						{newAllColumns.map((col) => {
+						{filteredColumns.map((col) => {
 							return (
 								<Checkbox value={col.id} key={col.id} checked={col.checked}>
 									{col.hdr}

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -35,8 +35,6 @@ export const TableFilter = <T extends Record<string, any>>({
 	const actionButtons = [
 		<Button
 			aria-label={apply}
-			style={{ color: "black" }}
-			variant="primary"
 			onClick={toggleFilterSheetVisible}
 			key="table-filter-apply-button"
 		>
@@ -44,7 +42,7 @@ export const TableFilter = <T extends Record<string, any>>({
 		</Button>,
 		<Button
 			aria-label={cancel}
-			variant="tertiary"
+			variant="secondary"
 			onClick={toggleFilterSheetVisible}
 			key="table-filter-cancel-button"
 		>

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -121,20 +121,20 @@ export const TableFilter = <T extends Record<string, any>>({
 
 	const actionButtons = [
 		<Button
-			aria-label={apply}
-			onClick={handleApplyChanges}
-			disabled={!applyBtnEnabled}
-			key="table-filter-apply-button"
-		>
-			{apply}
-		</Button>,
-		<Button
 			aria-label={cancel}
 			variant="secondary"
 			onClick={toggleFilterSheetVisible}
 			key="table-filter-cancel-button"
 		>
 			{cancel}
+		</Button>,
+		<Button
+			aria-label={apply}
+			onClick={handleApplyChanges}
+			disabled={!applyBtnEnabled}
+			key="table-filter-apply-button"
+		>
+			{apply}
 		</Button>,
 	];
 

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -19,7 +19,7 @@ type TableFilterProps<T extends Record<string, any>> = {
 
 type FilterColumns = {
 	id: string;
-	hdr: string | undefined | null;
+	checkboxDisplayText: string | undefined | null;
 	checked: boolean | "mixed";
 };
 
@@ -30,8 +30,7 @@ export const TableFilter = <T extends Record<string, any>>({
 }: TableFilterProps<T>) => {
 	// translations
 	const apply = translations.apply || defaultTranslations.toolbar.apply;
-	const cancel =
-		translations.cancel || defaultTranslations.toolbar.cancel || "Cancel";
+	const cancel = translations.cancel || defaultTranslations.toolbar.cancel;
 	const filterColumns =
 		translations.filterColumns ||
 		defaultTranslations.toolbar.filterColumns ||
@@ -51,6 +50,8 @@ export const TableFilter = <T extends Record<string, any>>({
 
 	const didColumnsSelectionsChange = useCallback(
 		(newVisibleColIds: IdType<T>[]) => {
+			if (newVisibleColIds.length < 1) return false; // disable Apply button if no columns are selected.
+
 			if (newVisibleColIds.length !== originalVisibleColIds.length) return true;
 
 			const arraysAreEqual = newVisibleColIds.every((id) =>
@@ -76,7 +77,7 @@ export const TableFilter = <T extends Record<string, any>>({
 				}
 				return {
 					id: col.id,
-					hdr: col.hdr,
+					checkboxDisplayText: col.checkboxDisplayText,
 					checked: col.id === value ? checked : col.checked,
 				};
 			});
@@ -95,7 +96,7 @@ export const TableFilter = <T extends Record<string, any>>({
 			const colProps = { ...col.getToggleHiddenProps() };
 			newAllCols.push({
 				id: col.id,
-				hdr: col.Header?.toString(),
+				checkboxDisplayText: col.Header?.toString(),
 				checked: colProps.checked,
 			});
 			if (colProps.checked) {
@@ -164,7 +165,7 @@ export const TableFilter = <T extends Record<string, any>>({
 						{filteredColumns.map((col) => {
 							return (
 								<Checkbox value={col.id} key={col.id} checked={col.checked}>
-									{col.hdr}
+									{col.checkboxDisplayText}
 								</Checkbox>
 							);
 						})}

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -26,7 +26,7 @@ export const TableFilter = <T extends Record<string, any>>({
 		"Filter Columns";
 
 	const { allColumns, setHiddenColumns } = instance;
-	console.log({instance});
+	console.log({ instance });
 
 	const { filterSheetVisible, toggleFilterSheetVisible } =
 		useContext(FilterContext);
@@ -70,13 +70,13 @@ export const TableFilter = <T extends Record<string, any>>({
 			>
 				<section>
 					{allColumns.map((column) => {
-				console.log(column.getToggleHiddenProps);
-				return (
-					<Checkbox key={column.id} {...column.getToggleHiddenProps()}>
-						{column.Header}
-					</Checkbox>
-				);
-			})}
+						console.log(column.getToggleHiddenProps);
+						return (
+							<Checkbox key={column.id} {...column.getToggleHiddenProps()}>
+								{column.Header}
+							</Checkbox>
+						);
+					})}
 				</section>
 			</Drawer>
 		</>

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -1,11 +1,7 @@
 import { useContext } from "react";
 import type { TableInstance } from "react-table";
 
-import { Button } from "components/Button";
-import { Checkbox } from "components/Checkbox";
-import { IconButton } from "components/IconButton";
-import { Sheet } from "components/Sheet";
-
+import { Button, Checkbox, Drawer, IconButton } from "components";
 import { FilterContext, translations as defaultTranslations } from "../helpers";
 import type { ITableFilterTranslations } from "../types";
 
@@ -21,6 +17,7 @@ export const TableFilter = <T extends Record<string, any>>({
 	instance,
 }: TableFilterProps<T>) => {
 	// translations
+	const apply = translations.apply || defaultTranslations.toolbar.apply;
 	const clear = translations.clear || defaultTranslations.toolbar.clear;
 	const close =
 		translations.close || defaultTranslations.toolbar.close || "Close";
@@ -30,20 +27,37 @@ export const TableFilter = <T extends Record<string, any>>({
 		"Filter Columns";
 
 	const { allColumns, setHiddenColumns } = instance;
+	console.log({instance});
 
 	const { filterSheetVisible, toggleFilterSheetVisible } =
 		useContext(FilterContext);
 
-	const buttons = [
-		<IconButton
-			aria-label={close}
-			icon="close"
-			shape="circle"
+	const actionButtons = [
+		<Button
+			aria-label={apply}
 			style={{ color: "black" }}
+			variant="primary"
+			onClick={toggleFilterSheetVisible}
+			key="table-filter-apply-button"
+		>
+			{apply}
+		</Button>,
+		<Button
+			aria-label={clear}
+			variant="secondary"
+			onClick={() => setHiddenColumns([])}
+			key="table-filter-reset-icon-button"
+		>
+			{clear}
+		</Button>,
+		<Button
+			aria-label={close}
 			variant="tertiary"
 			onClick={toggleFilterSheetVisible}
-			key="table-filter-close-icon-button"
-		/>,
+			key="table-filter-close-button"
+		>
+			{close}
+		</Button>,
 	];
 
 	return (
@@ -58,12 +72,10 @@ export const TableFilter = <T extends Record<string, any>>({
 				onClick={toggleFilterSheetVisible}
 			/>
 
-			<Sheet
-				actions={buttons}
-				className="neo-table__filters--sheet"
-				open={filterSheetVisible}
-				slide={filterSheetVisible}
+			<Drawer
 				title={filterColumns}
+				open={filterSheetVisible}
+				actions={actionButtons}
 			>
 				<section>
 					{allColumns.map((column) => (
@@ -72,29 +84,7 @@ export const TableFilter = <T extends Record<string, any>>({
 						</Checkbox>
 					))}
 				</section>
-
-				<div
-					className="neo-table__filters--sheet__footer"
-					style={{ flexWrap: "wrap" }}
-				>
-					<Button
-						onClick={() => setHiddenColumns([])}
-						size="wide"
-						status="alert"
-						variant="tertiary"
-					>
-						{clear}
-					</Button>
-
-					<Button
-						onClick={toggleFilterSheetVisible}
-						size="wide"
-						variant="tertiary"
-					>
-						{close}
-					</Button>
-				</div>
-			</Sheet>
+			</Drawer>
 		</>
 	);
 };

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -18,15 +18,16 @@ export const TableFilter = <T extends Record<string, any>>({
 }: TableFilterProps<T>) => {
 	// translations
 	const apply = translations.apply || defaultTranslations.toolbar.apply;
-	const close =
-		translations.close || defaultTranslations.toolbar.close || "Close";
+	const cancel =
+		translations.cancel || defaultTranslations.toolbar.cancel || "Cancel";
 	const filterColumns =
 		translations.filterColumns ||
 		defaultTranslations.toolbar.filterColumns ||
 		"Filter Columns";
 
-	const { allColumns, setHiddenColumns } = instance;
-	console.log({ instance });
+	const { allColumns, setHiddenColumns, visibleColumns } = instance;
+	// console.log({ instance });
+	console.log({ visibleColumns });
 
 	const { filterSheetVisible, toggleFilterSheetVisible } =
 		useContext(FilterContext);
@@ -42,12 +43,12 @@ export const TableFilter = <T extends Record<string, any>>({
 			{apply}
 		</Button>,
 		<Button
-			aria-label={close}
+			aria-label={cancel}
 			variant="tertiary"
 			onClick={toggleFilterSheetVisible}
-			key="table-filter-close-button"
+			key="table-filter-cancel-button"
 		>
-			{close}
+			{cancel}
 		</Button>,
 	];
 
@@ -70,7 +71,8 @@ export const TableFilter = <T extends Record<string, any>>({
 			>
 				<section>
 					{allColumns.map((column) => {
-						console.log(column.getToggleHiddenProps);
+						const colProps = { ...column.getToggleHiddenProps() };
+						console.log({colProps});
 						return (
 							<Checkbox key={column.id} {...column.getToggleHiddenProps()}>
 								{column.Header}

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -56,9 +56,12 @@ export const TableFilter = <T extends Record<string, any>>({
 
 			//Update newAllColumns array checked value
 			const nextColumns = newAllColumns.map((col) => {
-					 return { id: col.id, hdr: col.hdr, checked: col.id === value ? checked : col.checked }
-				}
-			);
+				return {
+					id: col.id,
+					hdr: col.hdr,
+					checked: col.id === value ? checked : col.checked,
+				};
+			});
 
 			setNewAllColumns(nextColumns);
 
@@ -90,11 +93,9 @@ export const TableFilter = <T extends Record<string, any>>({
 			const colProps = { ...col.getToggleHiddenProps() };
 			console.log({ colProps });
 			newAllCols.push({
-				key: col.id,
 				id: col.id,
 				hdr: col.Header?.toString(),
 				checked: colProps.checked,
-				title: colProps,
 			});
 		});
 		setNewAllColumns(newAllCols);
@@ -102,14 +103,20 @@ export const TableFilter = <T extends Record<string, any>>({
 	}, [allColumns]);
 
 	const handleApplyChanges = useCallback(() => {
-		const newHiddenColumns = allColumns.filter(
-			(col) => !newVizColumnIds.includes(col.id),
-		);
-		const newHiddenColIds = newHiddenColumns.map((col) => col.id);
+		const newHiddenColIds: IdType<T>[] = [];
+		newAllColumns.forEach((col) => {
+			if (!col.checked) {
+				newHiddenColIds.push(col.id);
+			}
+		});
 
 		setHiddenColumns(newHiddenColIds);
 		toggleFilterSheetVisible();
-	}, [allColumns, newVizColumnIds, setHiddenColumns, toggleFilterSheetVisible]);
+	}, [
+		newAllColumns,
+		setHiddenColumns,
+		toggleFilterSheetVisible,
+	]);
 
 	const actionButtons = [
 		<Button

--- a/src/components/Table/TableComponents/TableFilter.tsx
+++ b/src/components/Table/TableComponents/TableFilter.tsx
@@ -37,21 +37,16 @@ export const TableFilter = <T extends Record<string, any>>({
 		defaultTranslations.toolbar.filterColumns ||
 		"Filter Columns";
 
-	const { allColumns, setHiddenColumns, visibleColumns } = instance;
-	// console.log({ instance });
-	// console.log({ visibleColumns });
+	const { allColumns, setHiddenColumns } = instance;
 
 	const { filterSheetVisible, toggleFilterSheetVisible } =
 		useContext(FilterContext);
 
+	// newAllColumns is a temporary array that is used while the filter Drawer is open.
 	const [newAllColumns, setNewAllColumns] = useState<FilterColumns[]>([]);
-	const [newVizColumnIds, setNewVizColumnIds] = useState<IdType<T>[]>([]);
 
 	const handleColumnVisibilityChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
-			console.log("e.target: ", e.target);
-			// const newColumnIds: IdType<T>[] = [...newVizColumnIds];
-
 			const { checked, value } = e.target;
 
 			//Update newAllColumns array checked value
@@ -64,34 +59,15 @@ export const TableFilter = <T extends Record<string, any>>({
 			});
 
 			setNewAllColumns(nextColumns);
-
-			// if (e.target.checked) {
-			// 	//Add column to newVizColumnIds array
-			// 	setNewAllColumns([
-			// 		...newAllColumns,
-			// 		{ id: value, hdr: ariaLabel, checked: checked },
-			// 	]);
-			// 	// setNewVizColumnIds([...newColumnIds, e.target.id]);
-			// } else {
-			// 	console.log("Hiding colId: ", value);
-			// 	// Remove column from newVizColumnIds array
-			// 	// setNewVizColumnIds(newColumnIds.filter((id) => id !== e.target.id));
-			// 	setNewAllColumns(newAllColumns.filter((col) => col.id !== value));
-			// }
 		},
 		[newAllColumns],
 	);
 
 	useEffect(() => {
 		const newAllCols: FilterColumns[] = [];
-		// const newVizColIds: IdType<T>[] = [];
-		// visibleColumns.map((col) => {
-		// 	newVizColIds.push(col.id);
-		// });
 
 		allColumns.map((col) => {
 			const colProps = { ...col.getToggleHiddenProps() };
-			console.log({ colProps });
 			newAllCols.push({
 				id: col.id,
 				hdr: col.Header?.toString(),
@@ -99,7 +75,6 @@ export const TableFilter = <T extends Record<string, any>>({
 			});
 		});
 		setNewAllColumns(newAllCols);
-		// setNewVizColumnIds(newColumnIds);
 	}, [allColumns]);
 
 	const handleApplyChanges = useCallback(() => {
@@ -110,7 +85,7 @@ export const TableFilter = <T extends Record<string, any>>({
 			}
 		});
 
-		setHiddenColumns(newHiddenColIds);
+		setHiddenColumns(newHiddenColIds); // Using Table api to hide unchecked columns.
 		toggleFilterSheetVisible();
 	}, [
 		newAllColumns,

--- a/src/components/Table/helpers/default-data.ts
+++ b/src/components/Table/helpers/default-data.ts
@@ -2,7 +2,8 @@ import type { ITableTranslations } from "../types";
 
 export const translations: ITableTranslations = {
 	toolbar: {
-		clear: "Clear Filter",
+		apply: "Apply",
+		clear: "Reset",
 		close: "Close",
 		create: "Create",
 		delete: "Delete",

--- a/src/components/Table/helpers/default-data.ts
+++ b/src/components/Table/helpers/default-data.ts
@@ -3,6 +3,7 @@ import type { ITableTranslations } from "../types";
 export const translations: ITableTranslations = {
 	toolbar: {
 		apply: "Apply",
+		cancel: "Cancel",
 		clear: "Reset",
 		close: "Close",
 		create: "Create",

--- a/src/components/Table/types/TranslationTypes.ts
+++ b/src/components/Table/types/TranslationTypes.ts
@@ -1,6 +1,7 @@
 export interface ITableFilterTranslations {
 	clear?: string;
 	close?: string;
+	apply?: string;
 	filterColumns?: string;
 }
 export interface IToolbarTranslations extends ITableFilterTranslations {

--- a/src/components/Table/types/TranslationTypes.ts
+++ b/src/components/Table/types/TranslationTypes.ts
@@ -2,6 +2,7 @@ export interface ITableFilterTranslations {
 	clear?: string;
 	close?: string;
 	apply?: string;
+	cancel?: string;
 	filterColumns?: string;
 }
 export interface IToolbarTranslations extends ITableFilterTranslations {


### PR DESCRIPTION
[Link to Table example with Filter](https://deploy-preview-491--neo-react-library-storybook.netlify.app/?path=/story/components-table--server-side-pagination)
[Link to Figma reference](https://www.figma.com/file/o62kJbRQpFq9T0fGwKvCMA/Component-Exploration-FY22---v3?type=design&node-id=3313-531108&mode=design&t=A2jabCTteMz3HhD0-0)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

This PR completes Part 1 of the new Table Filter functionality that now uses a Drawer instead of a Sheet.

`@avaya-dux/dux-design`: Verify the new default behavior for the Table Filter Columns

- Clicking on the Filter button will invoke the Drawer that lists all columns, those visible should be checked.
- Checking / Unchecking columns will not take effect until the Apply button is pressed.
- The Apply button will only be enabled when the current selections actually change.
- After the Apply button is pressed the drawer will close and the appropriate columns will show or hide.
- Pressing the Cancel button will close the drawer while ignoring any changes done to the selections.
- "**not in scope**" Filter button states are still being decided and will be implemented in Part 2.
- "**not in scope**" Ability to provide custom Drawer or any other UI will be implemented in Part 2.

`@avaya-dux/dux-devs`: See notes for UX designers above to see new behavior test cases.

- We need to keep 2 different set of column arrays. One for the current state and another for the new state that will either be saved when the user clicks the Apply button or thrown away if the user clicks the Cancel button.
-  There is also another pair for arrays that only contain column ids that detects selection changes so that we can enable or disable the Apply button accordingly.
- I also updated the Table Filter tests since they now should verify we are using a Drawer component instead of a Sheet and we now require the user to click on Apply for changes to take place.
- "not in scope" The ability to provide a callback for the developer to provide their own UI will be done in Part 2.
![2024-08-13 12 52 00](https://github.com/user-attachments/assets/d994b119-2d19-4161-8cd4-a415e61f471e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new column filtering option in the table component, enhancing interactivity.
  - Implemented a `Drawer` for filter options, improving user experience.
  - Added new buttons for "Apply" and "Cancel" actions in the filter interface.

- **Bug Fixes**
  - Updated testing logic to align with the new visibility and interaction states of the dialog in the table component.

- **Documentation**
  - Revised translations for filter-related toolbar actions for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->