### PR TITLE
NEO-2280 // Pagination update part 1, remove tooltips and update Select

### DIFF
--- a/src/components/Pagination/Nodes/PaginationItemDisplay.tsx
+++ b/src/components/Pagination/Nodes/PaginationItemDisplay.tsx
@@ -1,7 +1,3 @@
-import { useMemo } from "react";
-
-import { Tooltip } from "components/Tooltip";
-
 import type { PaginationProps } from "..";
 
 /**
@@ -11,7 +7,6 @@ import type { PaginationProps } from "..";
  *
  * @example
  * <PaginationItemDisplay
- *  ariaLabelForCurrentPage={"Page Count"}
  *  currentPageIndex={3}
  *  itemCount={50}
  *  itemDisplayType="count"
@@ -22,52 +17,33 @@ import type { PaginationProps } from "..";
 export const PaginationItemDisplay = ({
 	currentPageIndex,
 	itemCount,
-	itemDisplayTooltipPosition = "auto",
 	itemDisplayType = "count",
 	itemsPerPage,
-	tooltipForCurrentPage = "Item count",
 	totalPages,
 }: { totalPages: number } & Pick<
 	PaginationProps,
-	| "currentPageIndex"
-	| "itemCount"
-	| "itemDisplayTooltipPosition"
-	| "itemDisplayType"
-	| "itemsPerPage"
-	| "tooltipForCurrentPage"
+	"currentPageIndex" | "itemCount" | "itemDisplayType" | "itemsPerPage"
 >) => {
-	const display = useMemo(() => {
-		if (itemDisplayType === "count") {
-			const startingItemIndex = (currentPageIndex - 1) * itemsPerPage + 1;
-			const endingItemIndex = Math.min(
-				startingItemIndex + itemsPerPage - 1,
-				itemCount,
-			);
+	if (itemDisplayType === "count") {
+		const startingItemIndex = (currentPageIndex - 1) * itemsPerPage + 1;
+		const endingItemIndex = Math.min(
+			startingItemIndex + itemsPerPage - 1,
+			itemCount,
+		);
 
-			return (
-				<bdi>
-					{startingItemIndex}-{endingItemIndex} / {itemCount}
-				</bdi>
-			);
-		}
-		if (itemDisplayType === "page") {
-			return (
-				<bdi>
-					{currentPageIndex} / {totalPages}
-				</bdi>
-			);
-		}
+		return (
+			<bdi>
+				{startingItemIndex}-{endingItemIndex} / {itemCount}
+			</bdi>
+		);
+	}
+	if (itemDisplayType === "page") {
+		return (
+			<bdi>
+				{currentPageIndex} / {totalPages}
+			</bdi>
+		);
+	}
 
-		return <></>;
-	}, [currentPageIndex, itemCount, itemDisplayType, itemsPerPage, totalPages]);
-
-	return (
-		<Tooltip
-			id={`pagination-item-display-${tooltipForCurrentPage}`}
-			label={tooltipForCurrentPage}
-			position={itemDisplayTooltipPosition}
-		>
-			{display}
-		</Tooltip>
-	);
+	return <></>;
 };

--- a/src/components/Pagination/Nodes/PaginationItemsPerPageSelection.tsx
+++ b/src/components/Pagination/Nodes/PaginationItemsPerPageSelection.tsx
@@ -1,52 +1,36 @@
-import { Tooltip } from "components/Tooltip";
+import { Select, SelectOption } from "components/Select";
 
 import type { PaginationProps } from "..";
 
 export const PaginationItemsPerPageSelection = ({
 	itemsPerPage,
-	itemsPerPageLabel = "Show: ",
+	itemsPerPageLabel = "Rows",
 	itemsPerPageOptions = [],
-	itemsPerPageTooltipPosition = "auto",
 	onItemsPerPageChange,
-	tooltipForShownPagesSelect = "items per page",
 }: Pick<
 	PaginationProps,
 	| "itemsPerPage"
 	| "itemsPerPageLabel"
 	| "itemsPerPageOptions"
 	| "onItemsPerPageChange"
-	| "tooltipForShownPagesSelect"
-	| "itemsPerPageTooltipPosition"
 >) => {
 	if (itemsPerPageOptions.length <= 0) {
 		return null;
 	}
 
 	return (
-		<Tooltip
-			id={`pagination-items-per-page-selection-${tooltipForShownPagesSelect}`}
-			label={tooltipForShownPagesSelect}
-			position={itemsPerPageTooltipPosition}
+		<Select
+			defaultValue={itemsPerPage.toString()}
+			label={itemsPerPageLabel}
+			onChange={(value) => {
+				onItemsPerPageChange?.(Number.parseInt(value as string, 10));
+			}}
 		>
-			<label>{itemsPerPageLabel}</label>
-
-			{/* // TODO-618: use our Select component when it is available */}
-			<select
-				aria-label={tooltipForShownPagesSelect}
-				defaultValue={itemsPerPage}
-				onBlur={(e) => {
-					onItemsPerPageChange?.(e, Number.parseInt(e.target.value, 10));
-				}}
-				onChange={(e) => {
-					onItemsPerPageChange?.(e, Number.parseInt(e.target.value, 10));
-				}}
-			>
-				{itemsPerPageOptions.map((option, i) => (
-					<option key={`option-${i}-${option}`} value={option}>
-						{option}
-					</option>
-				))}
-			</select>
-		</Tooltip>
+			{itemsPerPageOptions.map((option, i) => (
+				<SelectOption key={`option-${i}-${option}`} value={option.toString()}>
+					{option.toString()}
+				</SelectOption>
+			))}
+		</Select>
 	);
 };

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -87,8 +87,7 @@ const BookOfPages = ({
 
 							setPageIndex(newIndex);
 						}}
-						onItemsPerPageChange={(e, newItemsPerPage) => {
-							e?.preventDefault();
+						onItemsPerPageChange={(newItemsPerPage) => {
 							setLogItems([
 								<ListItem key={`${newItemsPerPage}-${genId()}`}>
 									setting new items per page: {newItemsPerPage}
@@ -178,6 +177,4 @@ Templated.args = {
 export const TooltipPositions = Template.bind({});
 TooltipPositions.args = {
 	...Templated.args,
-	itemsPerPageTooltipPosition: "left",
-	itemDisplayTooltipPosition: "right",
 };

--- a/src/components/Pagination/Pagination.test.jsx
+++ b/src/components/Pagination/Pagination.test.jsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/testing-react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { vi } from "vitest";
 
@@ -30,20 +30,15 @@ describe("Pagination", () => {
 	};
 
 	it("fully renders without exploding", () => {
-		vi.spyOn(console, "warn").mockImplementation(() => null);
-		const { getByRole, getAllByRole } = render(
-			<Pagination {...defaultProps} />,
-		);
+		render(<Pagination {...defaultProps} />);
 
-		const innerNavElement = getByRole("navigation");
-		const tooltips = getAllByRole("tooltip");
+		const innerNavElement = screen.getByRole("navigation");
+		const buttons = screen.getAllByRole("button");
 		expect(innerNavElement).toBeTruthy();
-		expect(tooltips).toHaveLength(2);
+		expect(buttons).toHaveLength(4);
 	});
 
 	it("does not render the `<select>` if no options are passed for it", () => {
-		vi.spyOn(console, "warn").mockImplementation(() => null);
-
 		const props = {
 			...defaultProps,
 			itemsPerPageOptions: undefined,
@@ -51,14 +46,12 @@ describe("Pagination", () => {
 		const { getByRole, getAllByRole } = render(<Pagination {...props} />);
 
 		const innerNavElement = getByRole("navigation");
-		const tooltips = getAllByRole("tooltip");
+		const buttons = getAllByRole("button");
 		expect(innerNavElement).toBeTruthy();
-		expect(tooltips).toHaveLength(1);
+		expect(buttons).toHaveLength(3);
 	});
 
 	it("does NOT show any nav items when `totalPages === 1`", () => {
-		vi.spyOn(console, "warn").mockImplementation(() => null);
-
 		const props = {
 			...defaultProps,
 			itemCount: 10,
@@ -70,12 +63,10 @@ describe("Pagination", () => {
 		expect(innerNavElement).toHaveLength(0);
 
 		const navItems = queryAllByRole("button");
-		expect(navItems).toHaveLength(0);
+		expect(navItems).toHaveLength(1); // only the "Rows" select
 	});
 
 	it("shows a single, nav item when `totalPages === 1` and prop `alwaysShowPagination` is passed", () => {
-		vi.spyOn(console, "warn").mockImplementation(() => null);
-
 		const props = {
 			...defaultProps,
 			itemCount: 10,
@@ -89,119 +80,10 @@ describe("Pagination", () => {
 		expect(innerNavElement).toHaveLength(1);
 
 		const navItems = queryAllByRole("button");
-		expect(navItems).toHaveLength(3); // left, 1, right
+		expect(navItems).toHaveLength(4); // left, 1, right, and "Rows" select
 		expect(navItems[0]).toBeDisabled();
 		expect(navItems[1]).toBeEnabled();
 		expect(navItems[2]).toBeDisabled();
-	});
-
-	it("matches it's previous snapshot", () => {
-		const { container } = render(
-			<Pagination {...defaultProps} id="pagination-test" />,
-		);
-		expect(container).toMatchInlineSnapshot(`
-			<div>
-			  <div
-			    class="neo-pagination__row"
-			    id="pagination-test"
-			  >
-			    <div
-			      class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
-			      id="pagination-item-display-Item count"
-			    >
-			      <bdi
-			        aria-describedby=":rc:"
-			      >
-			        1
-			        -
-			        1
-			         / 
-			        10
-			      </bdi>
-			      <div
-			        class="neo-tooltip__content neo-tooltip__content--multiline"
-			        id=":rc:"
-			        role="tooltip"
-			      >
-			        <div
-			          class="neo-arrow"
-			        />
-			        Item count
-			      </div>
-			    </div>
-			    <nav
-			      aria-label="pagination"
-			      class="neo-pagination"
-			    >
-			      <button
-			        aria-label="previous"
-			        class="neo-btn-square neo-pagination__arrow-btn neo-icon-arrow-left"
-			        disabled=""
-			        type="button"
-			      />
-			      <ul
-			        class="neo-pagination__list"
-			      >
-			        <li>
-			          <button
-			            class="neo-btn neo-btn--default neo-btn-secondary neo-btn-secondary--default neo-btn-square neo-btn-square-secondary neo-btn-square-secondary--info"
-			            data-badge=""
-			          >
-			            1
-			          </button>
-			        </li>
-			      </ul>
-			      <button
-			        aria-label="next"
-			        class="neo-btn-square neo-pagination__arrow-btn neo-icon-arrow-right"
-			        type="button"
-			      />
-			    </nav>
-			    <div
-			      class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
-			      id="pagination-items-per-page-selection-items per page"
-			    >
-			      <div
-			        aria-describedby=":rd:"
-			      >
-			        <label>
-			          Show: 
-			        </label>
-			        <select
-			          aria-label="items per page"
-			        >
-			          <option
-			            selected=""
-			            value="1"
-			          >
-			            1
-			          </option>
-			          <option
-			            value="5"
-			          >
-			            5
-			          </option>
-			          <option
-			            value="10"
-			          >
-			            10
-			          </option>
-			        </select>
-			      </div>
-			      <div
-			        class="neo-tooltip__content neo-tooltip__content--multiline"
-			        id=":rd:"
-			        role="tooltip"
-			      >
-			        <div
-			          class="neo-arrow"
-			        />
-			        items per page
-			      </div>
-			    </div>
-			  </div>
-			</div>
-		`);
 	});
 
 	it("passes basic axe compliance", async () => {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -7,6 +7,8 @@ import {
 } from "./Nodes/";
 import type { PaginationProps } from "./PaginationTypes";
 
+import "./Pagination_shim.css";
+
 /**
  * This component is used to render pagination.
  * It can be used as a standalone component.
@@ -43,7 +45,6 @@ export const Pagination = ({
 	manualPageCount = 0,
 
 	itemDisplayTooltipPosition,
-	itemsPerPageTooltipPosition,
 
 	alwaysShowPagination,
 	itemDisplayType,
@@ -55,7 +56,6 @@ export const Pagination = ({
 	backIconButtonText,
 	nextIconButtonText,
 	tooltipForCurrentPage,
-	tooltipForShownPagesSelect,
 
 	// default overrides
 	centerNode,
@@ -114,9 +114,7 @@ export const Pagination = ({
 					itemsPerPage={itemsPerPage}
 					itemsPerPageLabel={itemsPerPageLabel}
 					itemsPerPageOptions={itemsPerPageOptions}
-					itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 					onItemsPerPageChange={onItemsPerPageChange}
-					tooltipForShownPagesSelect={tooltipForShownPagesSelect}
 				/>
 			)}
 		</div>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -5,6 +5,7 @@ import {
 	PaginationItemsPerPageSelection,
 	PaginationNavigation,
 } from "./Nodes/";
+
 import type { PaginationProps } from "./PaginationTypes";
 
 import "./Pagination_shim.css";
@@ -44,8 +45,6 @@ export const Pagination = ({
 	itemsPerPageOptions,
 	manualPageCount = 0,
 
-	itemDisplayTooltipPosition,
-
 	alwaysShowPagination,
 	itemDisplayType,
 
@@ -55,7 +54,6 @@ export const Pagination = ({
 	// translations
 	backIconButtonText,
 	nextIconButtonText,
-	tooltipForCurrentPage,
 
 	// default overrides
 	centerNode,
@@ -87,11 +85,9 @@ export const Pagination = ({
 		<div className="neo-pagination__row" id={id} ref={rootRef}>
 			{leftNode || (
 				<PaginationItemDisplay
-					tooltipForCurrentPage={tooltipForCurrentPage}
 					currentPageIndex={currentPageIndex}
 					itemCount={itemCount}
 					itemDisplayType={itemDisplayType}
-					itemDisplayTooltipPosition={itemDisplayTooltipPosition}
 					itemsPerPage={itemsPerPage}
 					totalPages={totalPages}
 				/>

--- a/src/components/Pagination/PaginationTypes.ts
+++ b/src/components/Pagination/PaginationTypes.ts
@@ -2,7 +2,6 @@ export interface PaginationTranslations {
 	backIconButtonText?: string;
 	itemsPerPageLabel?: string;
 	nextIconButtonText?: string;
-	tooltipForCurrentPage?: string;
 }
 
 export type PaginationProps = {

--- a/src/components/Pagination/PaginationTypes.ts
+++ b/src/components/Pagination/PaginationTypes.ts
@@ -1,11 +1,8 @@
-import type { TooltipPosition } from "components/Tooltip";
-
 export interface PaginationTranslations {
 	backIconButtonText?: string;
 	itemsPerPageLabel?: string;
 	nextIconButtonText?: string;
 	tooltipForCurrentPage?: string;
-	tooltipForShownPagesSelect?: string;
 }
 
 export type PaginationProps = {
@@ -20,17 +17,11 @@ export type PaginationProps = {
 	alwaysShowPagination?: boolean;
 	itemDisplayType?: "count" | "page" | "none";
 
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
-
 	onPageChange: (
 		event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
 		pageIndex: number,
 	) => void;
-	onItemsPerPageChange?: (
-		event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-		itemsPerPage: number,
-	) => void;
+	onItemsPerPageChange?: (itemsPerPage: number) => void;
 
 	// table overrides
 	centerNode?: React.ReactNode;

--- a/src/components/Pagination/Pagination_shim.css
+++ b/src/components/Pagination/Pagination_shim.css
@@ -15,10 +15,14 @@
 	margin-right: 0;
 }
 
-.neo-input-group .neo-multiselect span.neo-multiselect-combo__header {
+.neo-pagination__row .neo-input-group .neo-multiselect span.neo-multiselect-combo__header {
 	min-height: 32px;
 }
 
-.neo-input-group .neo-multiselect span.neo-multiselect-combo__header button.neo-multiselect__header {
+.neo-pagination__row .neo-input-group .neo-multiselect span.neo-multiselect-combo__header button.neo-multiselect__header {
 	margin-right: 4px;
+}
+
+.neo-pagination__row .neo-multiselect span.neo-multiselect-combo__header button.neo-multiselect__header:last-child {
+	width: auto;
 }

--- a/src/components/Pagination/Pagination_shim.css
+++ b/src/components/Pagination/Pagination_shim.css
@@ -1,0 +1,24 @@
+.neo-pagination__row .neo-form-control .neo-input-group {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.neo-pagination__row .neo-form-control .neo-input-group label {
+	font-size: 14px;
+	padding-bottom: 0;
+}
+
+/* overrides */
+.neo-pagination__row .neo-multiselect {
+	margin-right: 0;
+}
+
+.neo-input-group .neo-multiselect span.neo-multiselect-combo__header {
+	min-height: 32px;
+}
+
+.neo-input-group .neo-multiselect span.neo-multiselect-combo__header button.neo-multiselect__header {
+	margin-right: 4px;
+}

--- a/src/components/Select/utils/SelectTypes.tsx
+++ b/src/components/Select/utils/SelectTypes.tsx
@@ -30,7 +30,7 @@ export type SelectProps = {
 	loading?: boolean;
 	multiple?: boolean;
 	noOptionsMessage?: string;
-	onChange?: (value: null | string | string[]) => void;
+	onChange?: (value: null | string | string[], event?: React.ChangeEvent<HTMLSelectElement>) => void;
 	placeholder?: string;
 	required?: boolean;
 	searchable?: boolean;

--- a/src/components/Select/utils/SelectTypes.tsx
+++ b/src/components/Select/utils/SelectTypes.tsx
@@ -30,7 +30,10 @@ export type SelectProps = {
 	loading?: boolean;
 	multiple?: boolean;
 	noOptionsMessage?: string;
-	onChange?: (value: null | string | string[], event?: React.ChangeEvent<HTMLSelectElement>) => void;
+	onChange?: (
+		value: null | string | string[],
+		event?: React.ChangeEvent<HTMLSelectElement>,
+	) => void;
 	placeholder?: string;
 	required?: boolean;
 	searchable?: boolean;

--- a/src/components/Table/Next/TableNext.tsx
+++ b/src/components/Table/Next/TableNext.tsx
@@ -62,8 +62,6 @@ export const TableNext = ({
 	// pagination options
 	itemsPerPageOptions = [10, 25, 50, 100],
 	initialStatePageIndex = 0,
-	itemDisplayTooltipPosition = "auto",
-	itemsPerPageTooltipPosition = "auto",
 
 	translations: translationsProp,
 
@@ -164,8 +162,6 @@ export const TableNext = ({
 				table={table}
 				itemsPerPageOptions={itemsPerPageOptions}
 				translations={translations.pagination}
-				itemDisplayTooltipPosition={itemDisplayTooltipPosition}
-				itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 			/>
 		</div>
 	);

--- a/src/components/Table/Next/components/TablePagination.tsx
+++ b/src/components/Table/Next/components/TablePagination.tsx
@@ -3,23 +3,18 @@ import { useMemo } from "react";
 
 import { Pagination } from "components/Pagination";
 import type { PaginationTranslations } from "components/Pagination/PaginationTypes";
-import type { TooltipPosition } from "components/Tooltip";
 
 import { translations as defaultTranslations } from "../../helpers";
 
 export const TablePagination = ({
 	table,
 	itemsPerPageOptions,
-	itemDisplayTooltipPosition,
-	itemsPerPageTooltipPosition,
 	translations,
 }: {
 	// biome-ignore lint/suspicious/noExplicitAny: we require maximum flexibility here
 	table: Table<any>;
 
 	itemsPerPageOptions?: number[];
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 
 	translations?: PaginationTranslations;
 }) => {
@@ -46,8 +41,7 @@ export const TablePagination = ({
 				e?.preventDefault();
 				setPageIndex(newIndex - 1);
 			}}
-			onItemsPerPageChange={(e, newItemsPerPage) => {
-				e?.preventDefault();
+			onItemsPerPageChange={(newItemsPerPage) => {
 				setPageSize(newItemsPerPage);
 
 				// when the user has chosen more rows, and there are thus fewer pages, check if we need to update the current page
@@ -59,12 +53,6 @@ export const TablePagination = ({
 			backIconButtonText={paginationTranslations.backIconButtonText}
 			itemsPerPageLabel={paginationTranslations.itemsPerPageLabel}
 			nextIconButtonText={paginationTranslations.nextIconButtonText}
-			tooltipForCurrentPage={paginationTranslations.tooltipForCurrentPage}
-			tooltipForShownPagesSelect={
-				paginationTranslations.tooltipForShownPagesSelect
-			}
-			itemDisplayTooltipPosition={itemDisplayTooltipPosition}
-			itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 		/>
 	);
 };

--- a/src/components/Table/Next/types/TableTypes.ts
+++ b/src/components/Table/Next/types/TableTypes.ts
@@ -1,6 +1,5 @@
 import type { ColumnDef } from "@tanstack/react-table";
 
-import type { TooltipPosition } from "components/Tooltip";
 import type { RowHeight } from "../../types";
 import type { ITableNextTranslations } from "./TranslationTypes";
 
@@ -19,8 +18,6 @@ export interface TableNextProps<T> {
 	// pagination options
 	itemsPerPageOptions?: number[];
 	initialStatePageIndex?: number;
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 	pushPaginationDown?: boolean;
 
 	translations?: ITableNextTranslations;

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -52,15 +52,6 @@ export const MultiSelectWithoutHelper = () => (
 	/>
 );
 
-export const TooltipPositioning = () => (
-	<Table
-		{...FilledFields}
-		itemDisplayTooltipPosition="top-right"
-		itemsPerPageTooltipPosition="top-left"
-		caption="Tooltip positioning in Pagination Example"
-	/>
-);
-
 export const MoreActionsMenu = () => (
 	<Table
 		caption="Last column has more actions menu."

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -101,13 +101,13 @@ describe("Table", () => {
 		it("respects when a user clicks to the next page", async () => {
 			render(<Table {...FilledFields} itemsPerPageOptions={[1, 2]} />);
 
-			expect(screen.getAllByText("1")).toHaveLength(2);
+			expect(screen.getAllByText("1")).toHaveLength(3);
 			expect(screen.getAllByText("2")).toHaveLength(1);
 
 			const nextButton = screen.getByLabelText("next");
 			await user.click(nextButton);
 
-			expect(screen.getAllByText("1")).toHaveLength(1);
+			expect(screen.getAllByText("1")).toHaveLength(2);
 			expect(screen.getAllByText("2")).toHaveLength(2);
 		});
 
@@ -124,8 +124,10 @@ describe("Table", () => {
 			const page5Button = page5Buttons[0];
 			expect(page5Button).toBeVisible();
 
-			const itemsPerPageSelect = screen.getByLabelText("items per page");
-			await userEvent.selectOptions(itemsPerPageSelect, "5");
+			await user.click(screen.getAllByRole("button").pop()); // open
+			await user.keyboard(UserEventKeys.DOWN); // move to first item (2	)
+			await user.keyboard(UserEventKeys.DOWN); // move to second item (5)
+			await user.keyboard(UserEventKeys.ENTER); // select second item (5)
 
 			const page2Buttons = screen.getAllByText("2");
 			const page2Button = page2Buttons[0];

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -111,8 +111,6 @@ export const Table = <T extends Record<string, any>>({
 	showRowHeightMenu = true,
 	showRowSelectionHelper = true,
 	showSearch = true,
-	itemDisplayTooltipPosition = "auto",
-	itemsPerPageTooltipPosition = "auto",
 	translations,
 
 	...rest
@@ -445,14 +443,6 @@ export const Table = <T extends Record<string, any>>({
 							backIconButtonText={paginationTranslations.backIconButtonText}
 							itemsPerPageLabel={paginationTranslations.itemsPerPageLabel}
 							nextIconButtonText={paginationTranslations.nextIconButtonText}
-							tooltipForCurrentPage={
-								paginationTranslations.tooltipForCurrentPage
-							}
-							tooltipForShownPagesSelect={
-								paginationTranslations.tooltipForShownPagesSelect
-							}
-							itemDisplayTooltipPosition={itemDisplayTooltipPosition}
-							itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 						/>
 					)}
 				</div>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -426,8 +426,7 @@ export const Table = <T extends Record<string, any>>({
 								setRootLevelPageIndex(nextIndex);
 								handlePageChange(nextIndex, pageSize);
 							}}
-							onItemsPerPageChange={(e, newItemsPerPage) => {
-								e?.preventDefault();
+							onItemsPerPageChange={(newItemsPerPage) => {
 								setPageSize(newItemsPerPage);
 
 								// when the user has chosen more rows, and there are thus fewer pages, check if we need to update the current page

--- a/src/components/Table/helpers/default-data.ts
+++ b/src/components/Table/helpers/default-data.ts
@@ -45,8 +45,6 @@ export const translations: ITableTranslations = {
 	pagination: {
 		backIconButtonText: "back",
 		nextIconButtonText: "next",
-		itemsPerPageLabel: "SHOW: ",
-		tooltipForCurrentPage: "current page",
-		tooltipForShownPagesSelect: "items per page",
+		itemsPerPageLabel: "Rows",
 	},
 };

--- a/src/components/Table/types/TableTypes.ts
+++ b/src/components/Table/types/TableTypes.ts
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import type { TableInstance, TableOptions } from "react-table";
 
-import type { TooltipPosition } from "components/Tooltip/TooltipTypes";
 import type {
 	IBodyTranslations,
 	ITableHeaderTranslations,
@@ -68,8 +67,6 @@ export type TableProps<T extends AnyRecord> = {
 	pushPaginationDown?: boolean;
 	draggableRows?: boolean;
 	handlePageChange?: (pageIndex: number, pageSize: number) => void;
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 	itemsPerPageOptions?: number[];
 	initialStatePageIndex?: number;
 	initialStatePageSize?: number;

--- a/src/components/Table/types/TranslationTypes.ts
+++ b/src/components/Table/types/TranslationTypes.ts
@@ -30,8 +30,6 @@ export interface IPaginationTranslations {
 	backIconButtonText?: string;
 	itemsPerPageLabel?: string;
 	nextIconButtonText?: string;
-	tooltipForCurrentPage?: string;
-	tooltipForShownPagesSelect?: string;
 }
 
 export interface ITableHeaderTranslations {


### PR DESCRIPTION
[Link to updated components in Deploy Preview](UPDATEMEWITHALINK)
[Link to Figma reference](UPDATEMEWITHALINK)

**Before tagging the team for a review, I have done the following:**

- [ ] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [ ] reviewed my code changes
- [ ] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [ ] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [ ] tagged `@avaya-dux/dux-devs`

This PR does two things:
- removes the tooltips from Pagination
- updates the Pagination Select to use the Neo-branded Select

`@avaya-dux/dux-design`: review Pagination Select ("Rows") for visual correctness

`@avaya-dux/dux-devs`: review refactor for any potential mistakes (I had to refactor WAY more than I anticipated) 
