### PR TITLE
NEO-2118 update DND to support upcoming inset table

### DIFF
--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -42,42 +42,46 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 	const cellCount = row.cells.length + 1 + (checkboxTd ? 1 : 0);
 
 	return (
-		<tr
-			ref={setNodeRef}
-			role={preparedRowProps.role}
-			style={{ ...style, ...preparedRowProps.style }}
-			key={preparedRowProps.key || `table-row-${row.id}`}
-			className={clsx(
-				row.isSelected && "active",
-				preparedRowProps.className,
-				row.original.disabled && "disabled",
-			)}
-			tabIndex={0}
-		>
-			{isDragging ? (
-				<EmptyRow colSpan={cellCount}>&nbsp;</EmptyRow>
-			) : (
-				<>
-					<td className="neo-table__dnd-td">
-						<DragHandle
-							ref={setActivatorNodeRef}
-							{...attributes}
-							{...listeners}
-						/>
-					</td>
-					{checkboxTd && (
-						<td style={{ padding: "0px 0px 0px 5px" }}>{checkboxTd}</td>
-					)}
-					{row.cells.map((cell) => {
-						const { key, ...restCellProps } = cell.getCellProps();
-						return (
-							<td {...restCellProps} key={key}>
-								{cell.render("Cell")}
-							</td>
-						);
-					})}
-				</>
-			)}
-		</tr>
+		<tbody ref={setNodeRef}>
+			<tr
+				role={preparedRowProps.role}
+				style={{ ...style, ...preparedRowProps.style }}
+				key={preparedRowProps.key || `table-row-${row.id}`}
+				className={clsx(
+					row.isSelected && "active",
+					preparedRowProps.className,
+					row.original.disabled && "disabled",
+				)}
+				tabIndex={0}
+			>
+				{isDragging ? (
+					<EmptyRow colSpan={cellCount}>&nbsp;</EmptyRow>
+				) : (
+					<>
+						<td className="neo-table__dnd-td">
+							<DragHandle
+								ref={setActivatorNodeRef}
+								{...attributes}
+								{...listeners}
+							/>
+						</td>
+						{checkboxTd && (
+							<td style={{ padding: "0px 0px 0px 5px" }}>{checkboxTd}</td>
+						)}
+						{row.cells.map((cell) => {
+							const { key, ...restCellProps } = cell.getCellProps();
+							return (
+								<td {...restCellProps} key={key}>
+									{cell.render("Cell")}
+								</td>
+							);
+						})}
+					</>
+				)}
+			</tr>
+			<tr>
+				<td colSpan={cellCount}>{isDragging ? "\u00A0" : "inset table"}</td>
+			</tr>
+		</tbody>
 	);
 };

--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -79,8 +79,14 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 					</>
 				)}
 			</tr>
-			<tr>
-				<td colSpan={cellCount}>{isDragging ? "\u00A0" : "inset table"}</td>
+			<tr
+				className={clsx(
+					row.isSelected && "active",
+					preparedRowProps.className,
+					row.original.disabled && "disabled",
+				)}
+			>
+				<td colSpan={cellCount}>inset table</td>
 			</tr>
 		</tbody>
 	);

--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -2,16 +2,11 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import clsx from "clsx";
 import type { Row } from "react-table";
-import styled from "styled-components";
 import { DragHandle } from "./DragHandle";
 
 import log from "loglevel";
 export const logger = log.getLogger("TableComponents/DraggableTableRow");
 logger.disableAll();
-
-const EmptyRow = styled.td`
-  background: var(--neo-color-blue-500);
-`;
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export const DraggableTableRow = <T extends Record<string, any>>({
@@ -42,10 +37,14 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 	const cellCount = row.cells.length + 1 + (checkboxTd ? 1 : 0);
 
 	return (
-		<tbody ref={setNodeRef}>
+		<tbody
+			ref={setNodeRef}
+			style={{ ...style }}
+			className={clsx(isDragging && "neo-table__tbody--dragging")}
+		>
 			<tr
 				role={preparedRowProps.role}
-				style={{ ...style, ...preparedRowProps.style }}
+				style={{ ...preparedRowProps.style }}
 				key={preparedRowProps.key || `table-row-${row.id}`}
 				className={clsx(
 					row.isSelected && "active",
@@ -54,38 +53,26 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 				)}
 				tabIndex={0}
 			>
-				{isDragging ? (
-					<EmptyRow colSpan={cellCount}>&nbsp;</EmptyRow>
-				) : (
-					<>
-						<td className="neo-table__dnd-td">
-							<DragHandle
-								ref={setActivatorNodeRef}
-								{...attributes}
-								{...listeners}
-							/>
+				<td className="neo-table__dnd-td">
+					<DragHandle
+						ref={setActivatorNodeRef}
+						{...attributes}
+						{...listeners}
+					/>
+				</td>
+				{checkboxTd && (
+					<td style={{ padding: "0px 0px 0px 5px" }}>{checkboxTd}</td>
+				)}
+				{row.cells.map((cell) => {
+					const { key, ...restCellProps } = cell.getCellProps();
+					return (
+						<td {...restCellProps} key={key}>
+							{cell.render("Cell")}
 						</td>
-						{checkboxTd && (
-							<td style={{ padding: "0px 0px 0px 5px" }}>{checkboxTd}</td>
-						)}
-						{row.cells.map((cell) => {
-							const { key, ...restCellProps } = cell.getCellProps();
-							return (
-								<td {...restCellProps} key={key}>
-									{cell.render("Cell")}
-								</td>
-							);
-						})}
-					</>
-				)}
+					);
+				})}
 			</tr>
-			<tr
-				className={clsx(
-					row.isSelected && "active",
-					preparedRowProps.className,
-					row.original.disabled && "disabled",
-				)}
-			>
+			<tr>
 				<td colSpan={cellCount}>inset table</td>
 			</tr>
 		</tbody>

--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -72,9 +72,11 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 					);
 				})}
 			</tr>
-			<tr>
-				<td colSpan={cellCount}>inset table</td>
-			</tr>
+			{row.isExpanded ? (
+				<tr>
+					<td colSpan={cellCount}>inset table</td>
+				</tr>
+			) : null}
 		</tbody>
 	);
 };

--- a/src/components/Table/StaticTableRow.tsx
+++ b/src/components/Table/StaticTableRow.tsx
@@ -42,9 +42,11 @@ export const StaticTableRow = <T extends Record<string, unknown>>({
 					);
 				})}
 			</tr>
-			<tr>
-				<td colSpan={cellCount}>inset table</td>
-			</tr>{" "}
+			{row.isExpanded ? (
+				<tr>
+					<td colSpan={cellCount}>inset table</td>
+				</tr>
+			) : null}
 		</tbody>
 	);
 };

--- a/src/components/Table/StaticTableRow.tsx
+++ b/src/components/Table/StaticTableRow.tsx
@@ -11,16 +11,18 @@ export const StaticTableRow = <T extends Record<string, unknown>>({
 	checkboxTd: JSX.Element | null;
 	showDragHandle: boolean;
 }) => {
+	const cellCount =
+		row.cells.length + (showDragHandle ? 1 : 0) + (checkboxTd ? 1 : 0);
+
 	const { key: _, ...restProps } = row.getRowProps();
 	return (
-		<tbody>
-			<tr
-				{...restProps}
-				className={clsx(
-					showDragHandle && "neo-set-keyboard-focus",
-					row.original.disabled ? "disabled" : undefined,
-				)}
-			>
+		<tbody
+			className={clsx(
+				showDragHandle && "neo-set-keyboard-focus",
+				row.original.disabled ? "disabled" : undefined,
+			)}
+		>
+			<tr {...restProps}>
 				{showDragHandle && (
 					<td className="neo-table__dnd-td">
 						<DragHandle />
@@ -41,7 +43,7 @@ export const StaticTableRow = <T extends Record<string, unknown>>({
 				})}
 			</tr>
 			<tr>
-				<td colSpan={row.cells.length}>inset table</td>
+				<td colSpan={cellCount}>inset table</td>
 			</tr>{" "}
 		</tbody>
 	);

--- a/src/components/Table/StaticTableRow.tsx
+++ b/src/components/Table/StaticTableRow.tsx
@@ -13,31 +13,36 @@ export const StaticTableRow = <T extends Record<string, unknown>>({
 }) => {
 	const { key: _, ...restProps } = row.getRowProps();
 	return (
-		<tr
-			{...restProps}
-			className={clsx(
-				showDragHandle && "neo-set-keyboard-focus",
-				row.original.disabled ? "disabled" : undefined,
-			)}
-		>
-			{showDragHandle && (
-				<td className="neo-table__dnd-td">
-					<DragHandle />
-				</td>
-			)}
-			{checkboxTd && (
-				<td style={{ padding: "0px 0px 0px 5px", width: "60px" }}>
-					{checkboxTd}
-				</td>
-			)}
-			{row.cells.map((cell) => {
-				const { key, ...restCellProps } = cell.getCellProps();
-				return (
-					<td key={key} {...restCellProps}>
-						<span>{cell.render("Cell")}</span>
+		<tbody>
+			<tr
+				{...restProps}
+				className={clsx(
+					showDragHandle && "neo-set-keyboard-focus",
+					row.original.disabled ? "disabled" : undefined,
+				)}
+			>
+				{showDragHandle && (
+					<td className="neo-table__dnd-td">
+						<DragHandle />
 					</td>
-				);
-			})}
-		</tr>
+				)}
+				{checkboxTd && (
+					<td style={{ padding: "0px 0px 0px 5px", width: "60px" }}>
+						{checkboxTd}
+					</td>
+				)}
+				{row.cells.map((cell) => {
+					const { key, ...restCellProps } = cell.getCellProps();
+					return (
+						<td key={key} {...restCellProps}>
+							<span>{cell.render("Cell")}</span>
+						</td>
+					);
+				})}
+			</tr>
+			<tr>
+				<td colSpan={row.cells.length}>inset table</td>
+			</tr>{" "}
+		</tbody>
 	);
 };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -467,14 +467,12 @@ export const Table = <T extends Record<string, any>>({
 							rowHeightValue === "medium" && "neo-table--medium",
 						)}
 					>
-						<tbody>
-							<StaticTableRow
-								key={selectedRow.original.id}
-								row={selectedRow}
-								showDragHandle={true}
-								checkboxTd={createCheckboxTd(selectedRow)}
-							/>
-						</tbody>
+						<StaticTableRow
+							key={selectedRow.original.id}
+							row={selectedRow}
+							showDragHandle={true}
+							checkboxTd={createCheckboxTd(selectedRow)}
+						/>
 					</table>
 				)}
 			</DragOverlay>

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -51,32 +51,34 @@ export const TableBody: TableBodyComponentType = ({
 		(shouldHaveCheckboxColumn ? 1 : 0) +
 		(draggableRows ? 1 : 0);
 	return (
-		<tbody {...getTableBodyProps()}>
-			<SortableContext items={rows} strategy={verticalListSortingStrategy}>
-				{page.length === 0 ? (
-					<tr>
-						<td colSpan={numberOfColumns}>{translations.noDataAvailable}</td>
-					</tr>
-				) : (
-					<>
-						{showRowSelectionHelper && (
-							<ClearSelectionRow
-								instance={instance}
-								selectableRows={selectableRows}
-								translations={translations}
-							/>
-						)}
-
-						<TableDataRows
-							handleRowToggled={handleRowToggled}
+		<SortableContext
+			items={rows}
+			strategy={verticalListSortingStrategy}
+			{...getTableBodyProps()}
+		>
+			{page.length === 0 ? (
+				<tr>
+					<td colSpan={numberOfColumns}>{translations.noDataAvailable}</td>
+				</tr>
+			) : (
+				<>
+					{showRowSelectionHelper && (
+						<ClearSelectionRow
 							instance={instance}
 							selectableRows={selectableRows}
 							translations={translations}
 						/>
-					</>
-				)}
-			</SortableContext>
-		</tbody>
+					)}
+
+					<TableDataRows
+						handleRowToggled={handleRowToggled}
+						instance={instance}
+						selectableRows={selectableRows}
+						translations={translations}
+					/>
+				</>
+			)}
+		</SortableContext>
 	);
 };
 

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -78,10 +78,10 @@
 	display: none;
 }
 
-.neo-table tbody tr:hover td.neo-table__dnd-td>div,
-.neo-table tbody tr:focus-within td.neo-table__dnd-td>div,
-.neo-table tbody tr.neo-set-keyboard-focus td.neo-table__dnd-td>div,
-.neo-table tbody tr:focus td.neo-table__dnd-td>div {
+.neo-table tbody:hover td.neo-table__dnd-td>div,
+.neo-table tbody:focus-within td.neo-table__dnd-td>div,
+.neo-table tbody.neo-set-keyboard-focus td.neo-table__dnd-td>div,
+.neo-table tbody:focus td.neo-table__dnd-td>div {
 	display: inline-block;
 }
 
@@ -93,6 +93,7 @@
 .neo-table th.neo-table__dnd-th:has(+ .neo-table-checkbox-th:hover) {
 	background-color: inherit;
 }
+
 
 .neo-table th.neo-table-checkbox-th {
 	padding: 0;
@@ -121,4 +122,10 @@
 			left: -30px;
 		}
 	}
+}
+
+/* replaces EmptyCell */
+.neo-table tbody.neo-table__tbody--dragging tr td {
+	color: transparent;
+	background: var(--neo-color-blue-500);
 }


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-497--neo-react-library-storybook.netlify.app/?path=/story/components-table--custom-actions)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [ ] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`


`@avaya-dux/dux-devs`:  To support drag and drop the row and its inset table as a whole, one structural change in dom is made: 
- a table can have many tbody
- a tbody now has a tr for the row data  and another tr for inset table content
- no visual changes to table and its DND behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the structure of table rows to improve semantic clarity, with conditional rendering for expanded content.
	- Introduced a dynamic inset table display for expanded rows in both draggable and static table rows.
  
- **Bug Fixes**
	- Resolved structural inconsistencies in the table rendering to align with HTML semantics.

- **Style**
	- Updated CSS for hover and focus states to target `tbody`, improving user interaction consistency.
	- Added new styles for dragging states to enhance visual feedback during row manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->