### PR TITLE
NEO-2280 // Pagination update part 1, remove tooltips

### DIFF
--- a/src/components/Pagination/Nodes/PaginationItemDisplay.tsx
+++ b/src/components/Pagination/Nodes/PaginationItemDisplay.tsx
@@ -1,7 +1,3 @@
-import { useMemo } from "react";
-
-import { Tooltip } from "components/Tooltip";
-
 import type { PaginationProps } from "..";
 
 /**
@@ -11,7 +7,6 @@ import type { PaginationProps } from "..";
  *
  * @example
  * <PaginationItemDisplay
- *  ariaLabelForCurrentPage={"Page Count"}
  *  currentPageIndex={3}
  *  itemCount={50}
  *  itemDisplayType="count"
@@ -22,52 +17,33 @@ import type { PaginationProps } from "..";
 export const PaginationItemDisplay = ({
 	currentPageIndex,
 	itemCount,
-	itemDisplayTooltipPosition = "auto",
 	itemDisplayType = "count",
 	itemsPerPage,
-	tooltipForCurrentPage = "Item count",
 	totalPages,
 }: { totalPages: number } & Pick<
 	PaginationProps,
-	| "currentPageIndex"
-	| "itemCount"
-	| "itemDisplayTooltipPosition"
-	| "itemDisplayType"
-	| "itemsPerPage"
-	| "tooltipForCurrentPage"
+	"currentPageIndex" | "itemCount" | "itemDisplayType" | "itemsPerPage"
 >) => {
-	const display = useMemo(() => {
-		if (itemDisplayType === "count") {
-			const startingItemIndex = (currentPageIndex - 1) * itemsPerPage + 1;
-			const endingItemIndex = Math.min(
-				startingItemIndex + itemsPerPage - 1,
-				itemCount,
-			);
+	if (itemDisplayType === "count") {
+		const startingItemIndex = (currentPageIndex - 1) * itemsPerPage + 1;
+		const endingItemIndex = Math.min(
+			startingItemIndex + itemsPerPage - 1,
+			itemCount,
+		);
 
-			return (
-				<bdi>
-					{startingItemIndex}-{endingItemIndex} / {itemCount}
-				</bdi>
-			);
-		}
-		if (itemDisplayType === "page") {
-			return (
-				<bdi>
-					{currentPageIndex} / {totalPages}
-				</bdi>
-			);
-		}
+		return (
+			<bdi>
+				{startingItemIndex}-{endingItemIndex} / {itemCount}
+			</bdi>
+		);
+	}
+	if (itemDisplayType === "page") {
+		return (
+			<bdi>
+				{currentPageIndex} / {totalPages}
+			</bdi>
+		);
+	}
 
-		return <></>;
-	}, [currentPageIndex, itemCount, itemDisplayType, itemsPerPage, totalPages]);
-
-	return (
-		<Tooltip
-			id={`pagination-item-display-${tooltipForCurrentPage}`}
-			label={tooltipForCurrentPage}
-			position={itemDisplayTooltipPosition}
-		>
-			{display}
-		</Tooltip>
-	);
+	return <></>;
 };

--- a/src/components/Pagination/Nodes/PaginationItemsPerPageSelection.tsx
+++ b/src/components/Pagination/Nodes/PaginationItemsPerPageSelection.tsx
@@ -1,38 +1,27 @@
-import { Tooltip } from "components/Tooltip";
-
 import type { PaginationProps } from "..";
 
 export const PaginationItemsPerPageSelection = ({
 	itemsPerPage,
-	itemsPerPageLabel = "Show: ",
+	itemsPerPageLabel = "Rows",
 	itemsPerPageOptions = [],
-	itemsPerPageTooltipPosition = "auto",
 	onItemsPerPageChange,
-	tooltipForShownPagesSelect = "items per page",
 }: Pick<
 	PaginationProps,
 	| "itemsPerPage"
 	| "itemsPerPageLabel"
 	| "itemsPerPageOptions"
 	| "onItemsPerPageChange"
-	| "tooltipForShownPagesSelect"
-	| "itemsPerPageTooltipPosition"
 >) => {
 	if (itemsPerPageOptions.length <= 0) {
 		return null;
 	}
 
 	return (
-		<Tooltip
-			id={`pagination-items-per-page-selection-${tooltipForShownPagesSelect}`}
-			label={tooltipForShownPagesSelect}
-			position={itemsPerPageTooltipPosition}
-		>
-			<label>{itemsPerPageLabel}</label>
+		<label>
+			{itemsPerPageLabel}
 
 			{/* // TODO-618: use our Select component when it is available */}
 			<select
-				aria-label={tooltipForShownPagesSelect}
 				defaultValue={itemsPerPage}
 				onBlur={(e) => {
 					onItemsPerPageChange?.(e, Number.parseInt(e.target.value, 10));
@@ -47,6 +36,6 @@ export const PaginationItemsPerPageSelection = ({
 					</option>
 				))}
 			</select>
-		</Tooltip>
+		</label>
 	);
 };

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -178,6 +178,4 @@ Templated.args = {
 export const TooltipPositions = Template.bind({});
 TooltipPositions.args = {
 	...Templated.args,
-	itemsPerPageTooltipPosition: "left",
-	itemDisplayTooltipPosition: "right",
 };

--- a/src/components/Pagination/Pagination.test.jsx
+++ b/src/components/Pagination/Pagination.test.jsx
@@ -36,9 +36,9 @@ describe("Pagination", () => {
 		);
 
 		const innerNavElement = getByRole("navigation");
-		const tooltips = getAllByRole("tooltip");
+		const buttons = getAllByRole("button");
 		expect(innerNavElement).toBeTruthy();
-		expect(tooltips).toHaveLength(2);
+		expect(buttons).toHaveLength(3);
 	});
 
 	it("does not render the `<select>` if no options are passed for it", () => {
@@ -51,9 +51,9 @@ describe("Pagination", () => {
 		const { getByRole, getAllByRole } = render(<Pagination {...props} />);
 
 		const innerNavElement = getByRole("navigation");
-		const tooltips = getAllByRole("tooltip");
+		const buttons = getAllByRole("button");
 		expect(innerNavElement).toBeTruthy();
-		expect(tooltips).toHaveLength(1);
+		expect(buttons).toHaveLength(3);
 	});
 
 	it("does NOT show any nav items when `totalPages === 1`", () => {
@@ -93,115 +93,6 @@ describe("Pagination", () => {
 		expect(navItems[0]).toBeDisabled();
 		expect(navItems[1]).toBeEnabled();
 		expect(navItems[2]).toBeDisabled();
-	});
-
-	it("matches it's previous snapshot", () => {
-		const { container } = render(
-			<Pagination {...defaultProps} id="pagination-test" />,
-		);
-		expect(container).toMatchInlineSnapshot(`
-			<div>
-			  <div
-			    class="neo-pagination__row"
-			    id="pagination-test"
-			  >
-			    <div
-			      class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
-			      id="pagination-item-display-Item count"
-			    >
-			      <bdi
-			        aria-describedby=":rc:"
-			      >
-			        1
-			        -
-			        1
-			         / 
-			        10
-			      </bdi>
-			      <div
-			        class="neo-tooltip__content neo-tooltip__content--multiline"
-			        id=":rc:"
-			        role="tooltip"
-			      >
-			        <div
-			          class="neo-arrow"
-			        />
-			        Item count
-			      </div>
-			    </div>
-			    <nav
-			      aria-label="pagination"
-			      class="neo-pagination"
-			    >
-			      <button
-			        aria-label="previous"
-			        class="neo-btn-square neo-pagination__arrow-btn neo-icon-arrow-left"
-			        disabled=""
-			        type="button"
-			      />
-			      <ul
-			        class="neo-pagination__list"
-			      >
-			        <li>
-			          <button
-			            class="neo-btn neo-btn--default neo-btn-secondary neo-btn-secondary--default neo-btn-square neo-btn-square-secondary neo-btn-square-secondary--info"
-			            data-badge=""
-			          >
-			            1
-			          </button>
-			        </li>
-			      </ul>
-			      <button
-			        aria-label="next"
-			        class="neo-btn-square neo-pagination__arrow-btn neo-icon-arrow-right"
-			        type="button"
-			      />
-			    </nav>
-			    <div
-			      class="neo-tooltip neo-tooltip--up neo-tooltip--onhover"
-			      id="pagination-items-per-page-selection-items per page"
-			    >
-			      <div
-			        aria-describedby=":rd:"
-			      >
-			        <label>
-			          Show: 
-			        </label>
-			        <select
-			          aria-label="items per page"
-			        >
-			          <option
-			            selected=""
-			            value="1"
-			          >
-			            1
-			          </option>
-			          <option
-			            value="5"
-			          >
-			            5
-			          </option>
-			          <option
-			            value="10"
-			          >
-			            10
-			          </option>
-			        </select>
-			      </div>
-			      <div
-			        class="neo-tooltip__content neo-tooltip__content--multiline"
-			        id=":rd:"
-			        role="tooltip"
-			      >
-			        <div
-			          class="neo-arrow"
-			        />
-			        items per page
-			      </div>
-			    </div>
-			  </div>
-			</div>
-		`);
 	});
 
 	it("passes basic axe compliance", async () => {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -5,6 +5,7 @@ import {
 	PaginationItemsPerPageSelection,
 	PaginationNavigation,
 } from "./Nodes/";
+
 import type { PaginationProps } from "./PaginationTypes";
 
 /**
@@ -42,9 +43,6 @@ export const Pagination = ({
 	itemsPerPageOptions,
 	manualPageCount = 0,
 
-	itemDisplayTooltipPosition,
-	itemsPerPageTooltipPosition,
-
 	alwaysShowPagination,
 	itemDisplayType,
 
@@ -54,8 +52,6 @@ export const Pagination = ({
 	// translations
 	backIconButtonText,
 	nextIconButtonText,
-	tooltipForCurrentPage,
-	tooltipForShownPagesSelect,
 
 	// default overrides
 	centerNode,
@@ -87,11 +83,9 @@ export const Pagination = ({
 		<div className="neo-pagination__row" id={id} ref={rootRef}>
 			{leftNode || (
 				<PaginationItemDisplay
-					tooltipForCurrentPage={tooltipForCurrentPage}
 					currentPageIndex={currentPageIndex}
 					itemCount={itemCount}
 					itemDisplayType={itemDisplayType}
-					itemDisplayTooltipPosition={itemDisplayTooltipPosition}
 					itemsPerPage={itemsPerPage}
 					totalPages={totalPages}
 				/>
@@ -114,9 +108,7 @@ export const Pagination = ({
 					itemsPerPage={itemsPerPage}
 					itemsPerPageLabel={itemsPerPageLabel}
 					itemsPerPageOptions={itemsPerPageOptions}
-					itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 					onItemsPerPageChange={onItemsPerPageChange}
-					tooltipForShownPagesSelect={tooltipForShownPagesSelect}
 				/>
 			)}
 		</div>

--- a/src/components/Pagination/PaginationTypes.ts
+++ b/src/components/Pagination/PaginationTypes.ts
@@ -1,11 +1,7 @@
-import type { TooltipPosition } from "components/Tooltip";
-
 export interface PaginationTranslations {
 	backIconButtonText?: string;
 	itemsPerPageLabel?: string;
 	nextIconButtonText?: string;
-	tooltipForCurrentPage?: string;
-	tooltipForShownPagesSelect?: string;
 }
 
 export type PaginationProps = {
@@ -19,9 +15,6 @@ export type PaginationProps = {
 
 	alwaysShowPagination?: boolean;
 	itemDisplayType?: "count" | "page" | "none";
-
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 
 	onPageChange: (
 		event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,

--- a/src/components/Table/Next/TableNext.tsx
+++ b/src/components/Table/Next/TableNext.tsx
@@ -62,8 +62,6 @@ export const TableNext = ({
 	// pagination options
 	itemsPerPageOptions = [10, 25, 50, 100],
 	initialStatePageIndex = 0,
-	itemDisplayTooltipPosition = "auto",
-	itemsPerPageTooltipPosition = "auto",
 
 	translations: translationsProp,
 
@@ -164,8 +162,6 @@ export const TableNext = ({
 				table={table}
 				itemsPerPageOptions={itemsPerPageOptions}
 				translations={translations.pagination}
-				itemDisplayTooltipPosition={itemDisplayTooltipPosition}
-				itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 			/>
 		</div>
 	);

--- a/src/components/Table/Next/components/TablePagination.tsx
+++ b/src/components/Table/Next/components/TablePagination.tsx
@@ -3,23 +3,18 @@ import { useMemo } from "react";
 
 import { Pagination } from "components/Pagination";
 import type { PaginationTranslations } from "components/Pagination/PaginationTypes";
-import type { TooltipPosition } from "components/Tooltip";
 
 import { translations as defaultTranslations } from "../../helpers";
 
 export const TablePagination = ({
 	table,
 	itemsPerPageOptions,
-	itemDisplayTooltipPosition,
-	itemsPerPageTooltipPosition,
 	translations,
 }: {
 	// biome-ignore lint/suspicious/noExplicitAny: we require maximum flexibility here
 	table: Table<any>;
 
 	itemsPerPageOptions?: number[];
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 
 	translations?: PaginationTranslations;
 }) => {
@@ -59,12 +54,6 @@ export const TablePagination = ({
 			backIconButtonText={paginationTranslations.backIconButtonText}
 			itemsPerPageLabel={paginationTranslations.itemsPerPageLabel}
 			nextIconButtonText={paginationTranslations.nextIconButtonText}
-			tooltipForCurrentPage={paginationTranslations.tooltipForCurrentPage}
-			tooltipForShownPagesSelect={
-				paginationTranslations.tooltipForShownPagesSelect
-			}
-			itemDisplayTooltipPosition={itemDisplayTooltipPosition}
-			itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 		/>
 	);
 };

--- a/src/components/Table/Next/types/TableTypes.ts
+++ b/src/components/Table/Next/types/TableTypes.ts
@@ -1,6 +1,5 @@
 import type { ColumnDef } from "@tanstack/react-table";
 
-import type { TooltipPosition } from "components/Tooltip";
 import type { RowHeight } from "../../types";
 import type { ITableNextTranslations } from "./TranslationTypes";
 
@@ -19,8 +18,6 @@ export interface TableNextProps<T> {
 	// pagination options
 	itemsPerPageOptions?: number[];
 	initialStatePageIndex?: number;
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 	pushPaginationDown?: boolean;
 
 	translations?: ITableNextTranslations;

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -52,15 +52,6 @@ export const MultiSelectWithoutHelper = () => (
 	/>
 );
 
-export const TooltipPositioning = () => (
-	<Table
-		{...FilledFields}
-		itemDisplayTooltipPosition="top-right"
-		itemsPerPageTooltipPosition="top-left"
-		caption="Tooltip positioning in Pagination Example"
-	/>
-);
-
 export const MoreActionsMenu = () => (
 	<Table
 		caption="Last column has more actions menu."

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -124,7 +124,9 @@ describe("Table", () => {
 			const page5Button = page5Buttons[0];
 			expect(page5Button).toBeVisible();
 
-			const itemsPerPageSelect = screen.getByLabelText("items per page");
+			const itemsPerPageSelect = screen.getByLabelText(
+				FilledFields.translations.pagination.itemsPerPageLabel,
+			);
 			await userEvent.selectOptions(itemsPerPageSelect, "5");
 
 			const page2Buttons = screen.getAllByText("2");

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -111,8 +111,6 @@ export const Table = <T extends Record<string, any>>({
 	showRowHeightMenu = true,
 	showRowSelectionHelper = true,
 	showSearch = true,
-	itemDisplayTooltipPosition = "auto",
-	itemsPerPageTooltipPosition = "auto",
 	translations,
 
 	...rest
@@ -445,14 +443,6 @@ export const Table = <T extends Record<string, any>>({
 							backIconButtonText={paginationTranslations.backIconButtonText}
 							itemsPerPageLabel={paginationTranslations.itemsPerPageLabel}
 							nextIconButtonText={paginationTranslations.nextIconButtonText}
-							tooltipForCurrentPage={
-								paginationTranslations.tooltipForCurrentPage
-							}
-							tooltipForShownPagesSelect={
-								paginationTranslations.tooltipForShownPagesSelect
-							}
-							itemDisplayTooltipPosition={itemDisplayTooltipPosition}
-							itemsPerPageTooltipPosition={itemsPerPageTooltipPosition}
 						/>
 					)}
 				</div>

--- a/src/components/Table/helpers/default-data.ts
+++ b/src/components/Table/helpers/default-data.ts
@@ -45,8 +45,6 @@ export const translations: ITableTranslations = {
 	pagination: {
 		backIconButtonText: "back",
 		nextIconButtonText: "next",
-		itemsPerPageLabel: "SHOW: ",
-		tooltipForCurrentPage: "current page",
-		tooltipForShownPagesSelect: "items per page",
+		itemsPerPageLabel: "Rows",
 	},
 };

--- a/src/components/Table/types/TableTypes.ts
+++ b/src/components/Table/types/TableTypes.ts
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import type { TableInstance, TableOptions } from "react-table";
 
-import type { TooltipPosition } from "components/Tooltip/TooltipTypes";
 import type {
 	IBodyTranslations,
 	ITableHeaderTranslations,
@@ -68,8 +67,6 @@ export type TableProps<T extends AnyRecord> = {
 	pushPaginationDown?: boolean;
 	draggableRows?: boolean;
 	handlePageChange?: (pageIndex: number, pageSize: number) => void;
-	itemDisplayTooltipPosition?: TooltipPosition;
-	itemsPerPageTooltipPosition?: TooltipPosition;
 	itemsPerPageOptions?: number[];
 	initialStatePageIndex?: number;
 	initialStatePageSize?: number;

--- a/src/components/Table/types/TranslationTypes.ts
+++ b/src/components/Table/types/TranslationTypes.ts
@@ -30,8 +30,6 @@ export interface IPaginationTranslations {
 	backIconButtonText?: string;
 	itemsPerPageLabel?: string;
 	nextIconButtonText?: string;
-	tooltipForCurrentPage?: string;
-	tooltipForShownPagesSelect?: string;
 }
 
 export interface ITableHeaderTranslations {


### PR DESCRIPTION
[Link to updated Pagination Default story](https://deploy-preview-498--neo-react-library-storybook.netlify.app/?path=/story/components-pagination--default)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

This is _only_ removing the Pagination tooltips. I discussed this with Matt, and the upcoming updates make them irrelevant. 

`@avaya-dux/dux-design`: Matt only, confirm that we do want the Tooltips gone by approving this PR

`@avaya-dux/dux-devs`: review code for any potential issues that I have not forseen ("Hide whitespace" to make the review easier).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined pagination components for improved usability.
	- Updated default label for items per page from "Show: " to "Rows".

- **Bug Fixes**
	- Removed tooltip functionality to enhance clarity in pagination options.

- **Documentation**
	- Updated stories to reflect changes in tooltip behavior within pagination components. 

- **Tests**
	- Revised test cases to focus on button elements instead of tooltips, ensuring consistency with the updated component structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->