### PR TITLE
NEO-2118 update table story to showcase various inset table content

### DIFF
--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -74,6 +74,7 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 						<IconButton
 							icon={row.isExpanded ? "chevron-down" : "chevron-right"}
 							size="compact"
+							iconSize="sm"
 							aria-label={row.isExpanded ? "expand" : "collapse"}
 							className="td-icon--expand"
 							{...row.getToggleRowExpandedProps({})}

--- a/src/components/Table/StaticTableRow.tsx
+++ b/src/components/Table/StaticTableRow.tsx
@@ -47,6 +47,7 @@ export const StaticTableRow = <T extends Record<string, unknown>>({
 						<IconButton
 							icon={row.isExpanded ? "chevron-down" : "chevron-right"}
 							size="compact"
+							iconSize="sm"
 							aria-label={row.isExpanded ? "expand" : "collapse"}
 							className="td-icon--expand"
 							{...row.getToggleRowExpandedProps({})}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -446,7 +446,7 @@ export const CustomActions = () => {
 	const [dark, setDark] = useState(false);
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	const renderInsetTable = (row: any) => {
-		console.log(row);
+		// inset table of 3 rows for name starting with "Sir"
 		if (row.original.name.startsWith("Sir"))
 			return (
 				<Table
@@ -458,6 +458,7 @@ export const CustomActions = () => {
 					data={[...FilledFields.data.slice(row.index, 3)]}
 				/>
 			);
+		// inline form for name starting with "Madam"
 		if (row.original.name.startsWith("Madam"))
 			return (
 				<Form aria-label="Playground form" inline>
@@ -482,7 +483,7 @@ export const CustomActions = () => {
 					</Button>
 				</Form>
 			);
-		return "inset table";
+		return <p>Name: {row.original.name}</p>;
 	};
 	return (
 		<div className={clsx(dark && "neo-dark")}>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -24,6 +24,7 @@ import {
 import { Button } from "components/Button";
 import type { IconNamesType } from "utils";
 
+import clsx from "clsx";
 import { Table, type TableProps } from "./";
 import {
 	FilledFields,
@@ -440,49 +441,57 @@ export const CustomActions = () => {
 	const [checked, setChecked] = useState(false);
 	const [multiple, setMultiple] = useState(false);
 	const [expandable, setExpandable] = useState(false);
-
+	const [dark, setDark] = useState(false);
 	return (
-		<Table
-			{...FilledFields}
-			draggableRows={checked}
-			selectableRows={multiple ? "multiple" : "none"}
-			caption="Custom Actions"
-			renderInsetTable={expandable ? () => "inset table" : undefined}
-			customActionsNode={
-				<section>
-					<Button
-						onClick={() => alert("custom action number one")}
-						variant="tertiary"
-					>
-						Example One
-					</Button>
-					<Button
-						onClick={() => alert("custom action number two")}
-						variant="tertiary"
-					>
-						Example Two
-					</Button>
-					<Switch
-						checked={checked}
-						onChange={(_e, updatedChecked) => setChecked(updatedChecked)}
-					>
-						Draggable Switch
-					</Switch>
-					<Switch
-						checked={multiple}
-						onChange={(_e, updatedChecked) => setMultiple(updatedChecked)}
-					>
-						Multiple Switch
-					</Switch>
-					<Switch
-						checked={expandable}
-						onChange={(_e, updatedChecked) => setExpandable(updatedChecked)}
-					>
-						Expandable Switch
-					</Switch>
-				</section>
-			}
-		/>
+		<div className={clsx(dark && "neo-dark")}>
+			<Table
+				{...FilledFields}
+				draggableRows={checked}
+				selectableRows={multiple ? "multiple" : "none"}
+				caption="Custom Actions"
+				renderInsetTable={expandable ? () => "inset table" : undefined}
+				customActionsNode={
+					<section>
+						<Button
+							onClick={() => alert("custom action number one")}
+							variant="tertiary"
+						>
+							Example One
+						</Button>
+						<Button
+							onClick={() => alert("custom action number two")}
+							variant="tertiary"
+						>
+							Example Two
+						</Button>
+						<Switch
+							checked={dark}
+							onChange={(_e, updatedChecked) => setDark(updatedChecked)}
+						>
+							Dark Mode
+						</Switch>
+						<Switch
+							checked={checked}
+							onChange={(_e, updatedChecked) => setChecked(updatedChecked)}
+						>
+							Draggable Switch
+						</Switch>
+						<Switch
+							checked={multiple}
+							onChange={(_e, updatedChecked) => setMultiple(updatedChecked)}
+						>
+							Multiple Switch
+						</Switch>
+						<Switch
+							checked={expandable}
+							onChange={(_e, updatedChecked) => setExpandable(updatedChecked)}
+						>
+							Expandable Switch
+						</Switch>
+					</section>
+				}
+			/>
+		</div>
 	);
 };
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -4,6 +4,7 @@ import type { Column, ColumnInstance, Row } from "react-table";
 
 import {
 	Chip,
+	Form,
 	Icon,
 	IconButton,
 	List,
@@ -19,6 +20,7 @@ import {
 	TabPanel,
 	TabPanels,
 	Tabs,
+	TextInput,
 	Tooltip,
 } from "components";
 import { Button } from "components/Button";
@@ -442,6 +444,45 @@ export const CustomActions = () => {
 	const [multiple, setMultiple] = useState(false);
 	const [expandable, setExpandable] = useState(false);
 	const [dark, setDark] = useState(false);
+	const renderInsetTable = (row: any) => {
+		console.log(row);
+		if (row.original.name.startsWith("Sir"))
+			return (
+				<Table
+					columns={FilledFields.columns}
+					showSearch={false}
+					readonly
+					showPagination={false}
+					pageCount={3}
+					data={[...FilledFields.data.slice(row.index, 3)]}
+				/>
+			);
+		if (row.original.name.startsWith("Madam"))
+			return (
+				<Form aria-label="Playground form" inline>
+					<TextInput
+						clearable
+						label="Name"
+						placeholder="Type your name here."
+						defaultValue={row.original.name}
+						type="text"
+					/>
+					<TextInput
+						clearable
+						label="Color"
+						defaultValue={row.original.hexValue}
+						type="text"
+					/>
+					<Button id="btn-submit-inline" variant="primary">
+						Submit
+					</Button>
+					<Button id="btnCancel" variant="secondary">
+						Cancel
+					</Button>
+				</Form>
+			);
+		return "inset table";
+	};
 	return (
 		<div className={clsx(dark && "neo-dark")}>
 			<Table
@@ -449,7 +490,7 @@ export const CustomActions = () => {
 				draggableRows={checked}
 				selectableRows={multiple ? "multiple" : "none"}
 				caption="Custom Actions"
-				renderInsetTable={expandable ? () => "inset table" : undefined}
+				renderInsetTable={expandable ? renderInsetTable : undefined}
 				customActionsNode={
 					<section>
 						<Button

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -444,6 +444,7 @@ export const CustomActions = () => {
 	const [multiple, setMultiple] = useState(false);
 	const [expandable, setExpandable] = useState(false);
 	const [dark, setDark] = useState(false);
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	const renderInsetTable = (row: any) => {
 		console.log(row);
 		if (row.original.name.startsWith("Sir"))

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -88,7 +88,7 @@ const ClearSelectionRow: TableBodyComponentType = ({
 	selectableRows,
 	translations,
 }) => {
-	const { draggableRows } = useContext(FilterContext);
+	const { draggableRows, hasInsetTable } = useContext(FilterContext);
 
 	const {
 		headers,
@@ -102,9 +102,10 @@ const ClearSelectionRow: TableBodyComponentType = ({
 	const columnsLength = useMemo(() => {
 		const checkboxColumns = shouldShowCheckbox ? 1 : 0;
 		const dragColumn = draggableRows ? 1 : 0;
+		const insetTableColumn = hasInsetTable ? 1 : 0;
 
-		return headers.length + checkboxColumns + dragColumn;
-	}, [draggableRows, headers.length, shouldShowCheckbox]);
+		return headers.length + checkboxColumns + dragColumn + insetTableColumn;
+	}, [draggableRows, headers.length, shouldShowCheckbox, hasInsetTable]);
 
 	const allTableEnabledRowsAreSelected = useMemo(() => {
 		const enabledTableRows = rows.filter((row) => !row.original.disabled);

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -23,6 +23,11 @@
 	:root .neo-dark .neo-table th button {
 		color: white;
 	}
+	
+	:root .neo-dynamic .neo-table td button.td-icon--expand,
+	:root .neo-dark .neo-table td button.td-icon--expand{
+		color: var(--neo-color-base-150);
+	}
 }
 
 .neo-table th button span {
@@ -140,7 +145,7 @@
 	height: 14px;
 	width: 14px;
 	align-items: center;
-	color: var(--base-black-100);
+	color: var(--neo-color-base-800);
 	background-image: inherit;
 	span[class*=neo-icon-]:before {
 		font-size: 14px;


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-504--neo-react-library-storybook.netlify.app/?path=/story/components-table--custom-actions)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

Dev only PR:
`@avaya-dux/dux-devs`: added Dark mode switch to Table -> CustomAction 
- show a table if row.name starts with Sir
- show a form if row.name starts with Madam
- show simple text for the rest

<img width="869" alt="Screenshot 2024-08-21 at 3 17 56 PM" src="https://github.com/user-attachments/assets/2152c969-ca64-4905-a9b8-a273fe401052">


<img width="971" alt="Screenshot 2024-08-21 at 3 16 27 PM" src="https://github.com/user-attachments/assets/181de6d5-0ac7-4da3-a9c7-9f6d64235fdc">



