### PR TITLE
ignore cypress downloads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules
 coverage
 cypress/integration/
 cypress/screenshots/
+cypress/downloads/
 cypress/videos/
 dist
 dist-ssr


### PR DESCRIPTION
just the title


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude the `cypress/downloads/` directory from version control, helping to maintain a cleaner repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->