### PR TITLE
NEO-2118  set expand cell width according to design

### DIFF
--- a/src/components/Table/DraggableTableRow.tsx
+++ b/src/components/Table/DraggableTableRow.tsx
@@ -75,6 +75,7 @@ export const DraggableTableRow = <T extends Record<string, any>>({
 							icon={row.isExpanded ? "chevron-down" : "chevron-right"}
 							size="compact"
 							iconSize="sm"
+							status="event"
 							aria-label={row.isExpanded ? "expand" : "collapse"}
 							className="td-icon--expand"
 							{...row.getToggleRowExpandedProps({})}

--- a/src/components/Table/StaticTableRow.tsx
+++ b/src/components/Table/StaticTableRow.tsx
@@ -48,6 +48,7 @@ export const StaticTableRow = <T extends Record<string, unknown>>({
 							icon={row.isExpanded ? "chevron-down" : "chevron-right"}
 							size="compact"
 							iconSize="sm"
+							status="event"
 							aria-label={row.isExpanded ? "expand" : "collapse"}
 							className="td-icon--expand"
 							{...row.getToggleRowExpandedProps({})}

--- a/src/components/Table/Table_shim.css
+++ b/src/components/Table/Table_shim.css
@@ -142,8 +142,8 @@
 
 .neo-table td button.td-icon--expand {
 	display: flex;
-	height: 14px;
-	width: 14px;
+	height: 32px;
+	width: 32px;
 	align-items: center;
 	color: var(--neo-color-base-800);
 	background-image: inherit;


### PR DESCRIPTION
[Link to updated components in Deploy Preview](UPDATEMEWITHALINK)
[Link to Figma reference](UPDATEMEWITHALINK)

**Before tagging the team for a review, I have done the following:**

- [ ] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [ ] reviewed my code changes
- [ ] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [ ] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [ ] tagged `@avaya-dux/dux-devs`

PR for Design to review:
`@avaya-dux/dux-design`:  
- Verify expand chevron according to Figma
- Other settings

`@avaya-dux/dux-devs`: minor changes
