### PR TITLE
NEO-2280 // Go To functionaility

### DIFF
--- a/src/components/Pagination/Nodes/GoToPage.tsx
+++ b/src/components/Pagination/Nodes/GoToPage.tsx
@@ -55,9 +55,8 @@ export const GoToPage = ({
 				}}
 			/>
 
-			<span>
-				/ {totalPages} {pagesText}
-			</span>
+			<span>/ {totalPages}</span>
+			<span>{pagesText}</span>
 		</div>
 	);
 };

--- a/src/components/Pagination/Nodes/GoToPage.tsx
+++ b/src/components/Pagination/Nodes/GoToPage.tsx
@@ -49,7 +49,10 @@ export const GoToPage = ({
 				}}
 				onKeyUp={(e) => {
 					if (e.key === Keys.ENTER) {
-						const v = (e.target as HTMLInputElement).valueAsNumber || 1;
+						let v = (e.target as HTMLInputElement).valueAsNumber || 1;
+						if (v < 1) v = 1;
+						if (v > totalPages) v = totalPages;
+
 						onPageChange(e, v);
 					}
 				}}

--- a/src/components/Pagination/Nodes/GoToPage.tsx
+++ b/src/components/Pagination/Nodes/GoToPage.tsx
@@ -49,7 +49,7 @@ export const GoToPage = ({
 				}}
 				onKeyUp={(e) => {
 					if (e.key === Keys.ENTER) {
-						const v = Number.parseInt((e.target as HTMLInputElement).value, 10);
+						const v = (e.target as HTMLInputElement).valueAsNumber || 1;
 						onPageChange(e, v);
 					}
 				}}

--- a/src/components/Pagination/Pagination.test.jsx
+++ b/src/components/Pagination/Pagination.test.jsx
@@ -94,36 +94,51 @@ describe("Pagination", () => {
 		expect(navItems[2]).toBeDisabled();
 	});
 
-	it("`GoToPage` responds to user input and page click appropriately", async () => {
-		render(<SettingTheDefaultIndex />);
-
-		const goToPageInput = screen.getByRole("spinbutton");
-		expect(goToPageInput).toHaveValue(5);
-
-		// when user clicks pagination arrows, `GoToPage` updates it's text input appropriately
-		const leftArrow = screen.getByLabelText("previous");
-		const rightArrow = screen.getByLabelText("next");
-		await user.click(leftArrow);
-		expect(goToPageInput).toHaveValue(4);
-		await user.click(rightArrow);
-		await user.click(rightArrow);
-		expect(goToPageInput).toHaveValue(6);
-
-		await user.type(goToPageInput, UserEventKeys.BACKSPACE);
-		await user.type(goToPageInput, "11");
-		expect(goToPageInput).toHaveValue(11);
-
-		await user.type(goToPageInput, UserEventKeys.ENTER);
-		await waitFor(() => {
-			const activePaginationPageButton = screen.getByText("11");
-			expect(activePaginationPageButton).toHaveClass(selectedPageClass);
-		});
-	});
-
 	it("passes basic axe compliance", async () => {
 		const { container } = render(<Pagination {...defaultProps} />);
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
+	});
+
+	describe("`GoToPage` functionality", () => {
+		it("`GoToPage` responds to user input and page click appropriately", async () => {
+			render(<SettingTheDefaultIndex />);
+
+			const goToPageInput = screen.getByRole("spinbutton");
+			expect(goToPageInput).toHaveValue(5);
+
+			// when user clicks pagination arrows, `GoToPage` updates it's text input appropriately
+			const leftArrow = screen.getByLabelText("previous");
+			const rightArrow = screen.getByLabelText("next");
+			await user.click(leftArrow);
+			expect(goToPageInput).toHaveValue(4);
+			await user.click(rightArrow);
+			await user.click(rightArrow);
+			expect(goToPageInput).toHaveValue(6);
+
+			await user.type(goToPageInput, UserEventKeys.BACKSPACE);
+			await user.type(goToPageInput, "11");
+			expect(goToPageInput).toHaveValue(11);
+
+			await user.type(goToPageInput, UserEventKeys.ENTER);
+			await waitFor(() => {
+				const activePaginationPageButton = screen.getByText("11");
+				expect(activePaginationPageButton).toHaveClass(selectedPageClass);
+			});
+		});
+
+		it("`GoToPage` sets value to `1` if users enters no value", async () => {
+			render(<SettingTheDefaultIndex />);
+
+			const goToPageInput = screen.getByRole("spinbutton");
+			expect(goToPageInput).toHaveValue(5);
+
+			await user.type(goToPageInput, UserEventKeys.BACKSPACE);
+			await user.type(goToPageInput, UserEventKeys.ENTER);
+			await waitFor(() => {
+				expect(screen.getByRole("spinbutton")).toHaveValue(1);
+			});
+		});
 	});
 
 	describe("storybook tests", () => {

--- a/src/components/Pagination/Pagination.test.jsx
+++ b/src/components/Pagination/Pagination.test.jsx
@@ -139,6 +139,32 @@ describe("Pagination", () => {
 				expect(screen.getByRole("spinbutton")).toHaveValue(1);
 			});
 		});
+
+		it("`GoToPage` sets value to `1` if users enters a value less than one", async () => {
+			render(<SettingTheDefaultIndex />);
+
+			const goToPageInput = screen.getByRole("spinbutton");
+			expect(goToPageInput).toHaveValue(5);
+
+			await user.type(goToPageInput, "-1");
+			await user.type(goToPageInput, UserEventKeys.ENTER);
+			await waitFor(() => {
+				expect(screen.getByRole("spinbutton")).toHaveValue(1);
+			});
+		});
+
+		it("`GoToPage` sets value to `totalPages` if users enters a value more than `totalPages`", async () => {
+			render(<SettingTheDefaultIndex />);
+
+			const goToPageInput = screen.getByRole("spinbutton");
+			expect(goToPageInput).toHaveValue(5);
+
+			await user.type(goToPageInput, "30000");
+			await user.type(goToPageInput, UserEventKeys.ENTER);
+			await waitFor(() => {
+				expect(screen.getByRole("spinbutton")).toHaveValue(20);
+			});
+		});
 	});
 
 	describe("storybook tests", () => {

--- a/src/components/Pagination/Pagination_shim.css
+++ b/src/components/Pagination/Pagination_shim.css
@@ -37,6 +37,10 @@
 		gap: 0.5rem;
 	}
 
+	.neo-input-editable__wrapper {
+		min-height: unset;
+	}
+
 	.neo-input {
 		height: 32px;
 		min-height: unset;

--- a/src/components/Pagination/Pagination_shim.css
+++ b/src/components/Pagination/Pagination_shim.css
@@ -37,10 +37,6 @@
 		align-items: center;
 		gap: 0.5rem;
 
-		.neo-input-editable__wrapper {
-			width: -webkit-fill-available;
-		}
-
 		.neo-input {
 			max-width: unset;
 			padding-right: 6px;

--- a/src/components/Pagination/Pagination_shim.css
+++ b/src/components/Pagination/Pagination_shim.css
@@ -32,9 +32,19 @@
 	gap: 1rem;
 
 	.pagination__go-to-page {
-		display: flex;
+		display: grid;
+		grid-template-columns: 1fr auto auto;
 		align-items: center;
 		gap: 0.5rem;
+
+		.neo-input-editable__wrapper {
+			width: -webkit-fill-available;
+		}
+
+		.neo-input {
+			max-width: unset;
+			padding-right: 6px;
+		}
 	}
 
 	.neo-input-editable__wrapper {


### PR DESCRIPTION
[Link to Table story](https://deploy-preview-511--neo-react-library-storybook.netlify.app/?path=/story/components-table--server-side-pagination)
[Link to Figma reference](https://www.figma.com/design/SQHQlIhFHWCjngHZOnK8MH/Web-Components-2.0?node-id=6170-2353&t=gPh9ofqp708VwfSe-0)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

Adding basic "go to" functionality to pagination. 

**IMPORTANT**: I tested with VO and a11y is definitely not working as intended. I've [added a note](https://teams.microsoft.com/l/message/19:51f2a46da4674b958166ab02f482a977@thread.tacv2/1724875660320?tenantId=04a2636c-326d-48ff-93f8-709875bd3aa9&groupId=853bb606-e586-482d-9bb8-a0a0af53510d&parentMessageId=1724859305794&teamName=UX%2FUI%20Team%20%F0%9F%8E%A8&channelName=Accessibility%20Q%20and%20A&createdTime=1724875660320) to our next Terri session to ask her what is supposed to happen. 

`@avaya-dux/dux-design`: Review figma and implementation for matching visuals.

- confirm that the visuals match (or are close enough)
- confirm that the "go to" input works as expected
- if there are improvements to be made, note them so we can discuss if they should be done in this PR or a future one
- note that the input width changes based on maximum page number, please update the row count to see different width
 - for example, use [this story](https://deploy-preview-511--neo-react-library-storybook.netlify.app/?path=/story/components-table--default) to see smaller input width, and [this story](https://deploy-preview-511--neo-react-library-storybook.netlify.app/?path=/story/components-table--server-side-pagination) for large input wdith

`@avaya-dux/dux-devs`: General functionality was approved in [previous PR](https://github.com/avaya-dux/neo-react-library/pull/503). Double check for bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced input handling in the pagination component for improved robustness when entering page numbers.
  - Improved rendering of pagination text for better clarity and structure.

- **Style**
  - Updated pagination styling to utilize a grid layout, enhancing responsiveness and organization.
  - Adjusted input field styles for improved appearance and spacing.

- **Tests**
  - Expanded testing suite for the pagination component, including edge cases for input handling and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->