### PR TITLE
NEO-2357  hide delete button when handleDelete is undefined or null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -505,6 +505,57 @@ describe("Table", () => {
 			expect(mock).toHaveBeenCalled();
 		});
 
+		it("properly hides `delete` button when handleDelete is not defined", async () => {
+			const { getByText, queryAllByRole } = render(
+				<Table
+					{...FilledFields}
+					itemsPerPageOptions={[50]}
+					selectableRows="multiple"
+				/>,
+			);
+
+			// expect button to not be rendered when zero rows are selected
+			expect(() =>
+				getByText(FilledFields.translations.toolbar.delete),
+			).toThrow();
+
+			// select first row
+			const firstRowCheckboxLabel =
+				queryAllByRole("row")[1].querySelector("label");
+			await user.click(firstRowCheckboxLabel);
+
+			// delete is hidden since handleDelete is not defined
+			expect(() =>
+				getByText(FilledFields.translations.toolbar.delete),
+			).toThrow();
+		});
+
+		it("properly hides `delete` button when handleDelete is null", async () => {
+			const { getByText, queryAllByRole } = render(
+				<Table
+					{...FilledFields}
+					itemsPerPageOptions={[50]}
+					handleDelete={null}
+					selectableRows="multiple"
+				/>,
+			);
+
+			// expect button to not be rendered when zero rows are selected
+			expect(() =>
+				getByText(FilledFields.translations.toolbar.delete),
+			).toThrow();
+
+			// select first row
+			const firstRowCheckboxLabel =
+				queryAllByRole("row")[1].querySelector("label");
+			await user.click(firstRowCheckboxLabel);
+
+			// delete is hidden since handleDelete is null
+			expect(() =>
+				getByText(FilledFields.translations.toolbar.delete),
+			).toThrow();
+		});
+
 		it("properly calls it's `delete` method", async () => {
 			const mock = vi.fn();
 			const { getByText, queryAllByRole } = render(

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -198,15 +198,15 @@ export const Table = <T extends Record<string, any>>({
 		[rows, originalData, dataSyncOption],
 	);
 
-	const handleDeleteWrapper = useCallback(
-		(selectedRowsIds: string[]) => {
-			if (handleDelete) {
+	const handleDeleteWrapper = useMemo(() => {
+		if (handleDelete) {
+			return (selectedRowsIds: string[]) => {
 				handleDelete(selectedRowsIds);
 				toggleAllRowsSelected(false);
-			}
-		},
-		[handleDelete, toggleAllRowsSelected],
-	);
+			};
+		}
+		return undefined;
+	}, [handleDelete, toggleAllRowsSelected]);
 
 	logger.debug(
 		"Table: originalData",


### PR DESCRIPTION
[Editable](https://deploy-preview-516--neo-react-library-storybook.netlify.app/?path=/story/components-table--editable-data)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

`@avaya-dux/dux-devs`:  hide delete button when handleDelete is undefined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@avaya/neo-react` package to version 1.2.6, introducing backward-compatible bug fixes and enhancements.
  
- **Tests**
	- Added new test cases for the `Table` component to verify the visibility of the `delete` button based on the `handleDelete` prop, improving test coverage for edge cases.

- **Refactor**
	- Revised the implementation of the `handleDeleteWrapper` function in the `Table` component for improved performance and behavior regarding the `delete` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->