### PR TITLE
NEO-2112 refactor code

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -261,8 +261,6 @@ export const AdvancedFilteringAndSorting = () => {
 		{
 			Header: "Level",
 			accessor: "level",
-			disableFilters: true,
-
 			sortType: (rowA, rowB) => {
 				const {
 					original: { level: levelA },
@@ -303,7 +301,6 @@ export const AdvancedFilteringAndSorting = () => {
 			},
 			Header: "Has On Call Beeper",
 			accessor: "hasOnCallBeeper",
-			disableFilters: true,
 			sortType: (row) => (row.original.hasOnCallBeeper ? 1 : -1), // `boolean` is not supported by default
 			width: 75,
 			filter: "includesValue",
@@ -314,7 +311,6 @@ export const AdvancedFilteringAndSorting = () => {
 			),
 			Header: "Date",
 			accessor: "date",
-			disableFilters: true,
 			sortType: "datetime",
 			filter: "includesValue",
 		},
@@ -378,7 +374,6 @@ export const AdvancedFilteringAndSorting = () => {
 			accessor: "status",
 			disableSortBy: true,
 			filter: "exactTextCase",
-			disableFilters: false,
 		},
 		{
 			Cell: ({ value }: { value: IDataTableMockData["longText"] }) =>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -451,7 +451,7 @@ export const Table = <T extends Record<string, any>>({
 							translations={toolbarTranslations}
 						/>
 					)}
-					<TableColumnFilterDrawer />
+					<TableColumnFilterDrawer translations={headerTranslations} />
 					<table
 						{...getTableProps()}
 						className={clsx(

--- a/src/components/Table/TableComponents/TableColumnFilter.tsx
+++ b/src/components/Table/TableComponents/TableColumnFilter.tsx
@@ -11,6 +11,12 @@ const logger = log.getLogger("table-column-filter-logger");
 logger.disableAll();
 
 export { logger as tableColumnFilterLogger };
+
+// Utility function to get the string representation of a column header
+const getColumnHeaderString = (column?: ColumnInstance<AnyRecord>) => {
+	return column?.render("Header") ?? "";
+};
+
 // given a column, return a default filter UI wrapped in TableFilterDrawer
 export const TableColumnFilterDrawer = ({
 	translations,
@@ -50,7 +56,7 @@ export const TableColumnFilterDrawer = ({
 
 	return (
 		<TableFilterDrawer
-			title={`Filter by column: ${column?.Header}`}
+			title={`Filter by column: ${getColumnHeaderString(column)}`}
 			open={!!filterComponent}
 			handleApply={handleApply}
 			handleCancel={handleCancel}

--- a/src/components/Table/TableComponents/TableColumnFilter.tsx
+++ b/src/components/Table/TableComponents/TableColumnFilter.tsx
@@ -121,10 +121,7 @@ export const CheckboxGroupFilter = <T extends AnyRecord>({
 	logger.debug("CheckboxGroupFilter options", options);
 	return (
 		<CheckboxGroup
-			label={
-				translations.checkboxGroupFilterLabel ||
-				"Check one or more values to filter"
-			}
+			label={translations.checkboxGroupFilterLabel}
 			groupName={id}
 			onChange={(e) => {
 				const value = e.target.value;

--- a/src/components/Table/TableComponents/TableColumnFilter.tsx
+++ b/src/components/Table/TableComponents/TableColumnFilter.tsx
@@ -4,7 +4,7 @@ import log from "loglevel";
 import { useCallback, useContext, useMemo, useState } from "react";
 import type { ColumnInstance, IdType, Row } from "react-table";
 import { FilterContext } from "../helpers";
-import type { AnyRecord } from "../types";
+import type { AnyRecord, ITableHeaderTranslations } from "../types";
 import { TableFilterDrawer } from "./TableFilterDrawer";
 
 const logger = log.getLogger("table-column-filter-logger");
@@ -12,7 +12,9 @@ logger.disableAll();
 
 export { logger as tableColumnFilterLogger };
 // given a column, return a default filter UI wrapped in TableFilterDrawer
-export const TableColumnFilterDrawer = () => {
+export const TableColumnFilterDrawer = ({
+	translations,
+}: { translations: ITableHeaderTranslations }) => {
 	const { filterColumn: column, setFilterColumn } = useContext(FilterContext);
 	const [newFilterValue, setNewFilterValue] = useState(column?.filterValue);
 
@@ -22,11 +24,15 @@ export const TableColumnFilterDrawer = () => {
 
 		if (filter === "includesValue") {
 			return (
-				<CheckboxGroupFilter column={column} onChange={setNewFilterValue} />
+				<CheckboxGroupFilter
+					column={column}
+					onChange={setNewFilterValue}
+					translations={translations}
+				/>
 			);
 		}
 		return <DefaultColumnFilter column={column} onChange={setNewFilterValue} />;
-	}, [column]);
+	}, [column, translations]);
 
 	const handleCancel = useCallback(() => {
 		const { setFilter, filterValue } = column || {};
@@ -44,7 +50,7 @@ export const TableColumnFilterDrawer = () => {
 
 	return (
 		<TableFilterDrawer
-			title="Filter by column"
+			title={`Filter by column: ${column?.Header}`}
 			open={!!filterComponent}
 			handleApply={handleApply}
 			handleCancel={handleCancel}
@@ -89,7 +95,12 @@ const convertValueToString = (value: unknown): string => {
 export const CheckboxGroupFilter = <T extends AnyRecord>({
 	column,
 	onChange,
-}: { column: ColumnInstance<T>; onChange: React.Dispatch<unknown> }) => {
+	translations,
+}: {
+	column: ColumnInstance<T>;
+	onChange: React.Dispatch<unknown>;
+	translations: ITableHeaderTranslations;
+}) => {
 	const { id, preFilteredRows } = column;
 	logger.debug("CheckboxGroupFilter filterValue", column.filterValue);
 	const [filterValue, setFilterValue] = useState(column.filterValue || []);
@@ -104,7 +115,10 @@ export const CheckboxGroupFilter = <T extends AnyRecord>({
 	logger.debug("CheckboxGroupFilter options", options);
 	return (
 		<CheckboxGroup
-			label={id}
+			label={
+				translations.checkboxGroupFilterLabel ||
+				"Check one or more values to filter"
+			}
 			groupName={id}
 			onChange={(e) => {
 				const value = e.target.value;

--- a/src/components/Table/helpers/default-data.ts
+++ b/src/components/Table/helpers/default-data.ts
@@ -36,6 +36,8 @@ export const translations: ITableTranslations = {
 		clearAllPages: "Clear all items on all pages",
 		selectAll: "Select all items",
 		clearAll: "Clear all items",
+		// column filter translations
+		checkboxGroupFilterLabel: "Check one or more values to filter",
 	},
 	body: {
 		noDataAvailable: "no data available",

--- a/src/components/Table/helpers/mock-data.tsx
+++ b/src/components/Table/helpers/mock-data.tsx
@@ -21,18 +21,15 @@ const columnsExample: Array<Column<IDataTableMockData>> = [
 	{
 		Header: "Name",
 		accessor: "name",
-		disableFilters: true, // HACK: need to update to not need this
 	},
 	{
 		Header: "Color",
 		accessor: "hexValue",
-		disableFilters: true,
 		sortType: "alphanumeric",
 	},
 	{
 		Header: "Other",
 		accessor: "other",
-		disableFilters: true,
 		disableSortBy: true,
 	},
 ];

--- a/src/components/Table/types/TranslationTypes.ts
+++ b/src/components/Table/types/TranslationTypes.ts
@@ -49,6 +49,9 @@ export interface ITableHeaderTranslations {
 	clearAllPages: string;
 	selectAll: string;
 	clearAll: string;
+
+	// column filter translations
+	checkboxGroupFilterLabel: string;
 }
 
 export interface ITableTranslations {


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-526--neo-react-library-storybook.netlify.app/?path=/story/components-table--advanced-filtering-and-sorting)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY:  added a checkbox group column filter screen for Date column
`@avaya-dux/dux-devs`: 
- clean up code
- remove biome suppress comments
- date formatting
- removed "disableFilters" prop and not seeing any side effects
<img width="670" alt="Screenshot 2024-09-10 at 12 49 48 PM" src="https://github.com/user-attachments/assets/894730c3-ebea-415c-98b7-5a02bc6eee98">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering capabilities for the "Level," "Has On Call Beeper," "Date," "Name," and "Color" columns in the data table.
	- Default filtering enabled for the "status" column.
	- Added a new translation entry for checkbox group filter instructions.

- **Improvements**
	- Improved type safety and clarity in the `CheckboxGroupFilter` functionality.
	- Introduced a new helper function for consistent data type conversion to strings.

- **Documentation**
	- Added comments to clarify code functionality and intent for future developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->