### PR TITLE
replace `@media` with `@container`

### DIFF
--- a/src/components/Pagination/Pagination_shim.css
+++ b/src/components/Pagination/Pagination_shim.css
@@ -1,4 +1,9 @@
-@media (min-width: 900px) {
+*:has(>.neo-pagination__row) {
+	container-name: pagination;
+	container-type: inline-size;
+}
+
+@container pagination (inline-size > 1000px) {
 	.neo-pagination__row {
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;


### PR DESCRIPTION
[Link to updated Pagination](https://deploy-preview-531--neo-react-library-storybook.netlify.app/?path=/docs/components-pagination--docs)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

Have Pagination respond to the container width, not screen width.

I played with this a bunch and I unfortunatly couldn't find a better solution than `*:has()`. I don't mess with the `*`s props, so I think that this is fine. Not ideal I know, but I'm really sick of messing with this and I need to get this done before moving on to my next ticket.

Also, I'm loving CodeRabbit's poems recently!
![Screenshot 2024-09-12 at 09 58 53](https://github.com/user-attachments/assets/e0a4174f-f6e5-4135-9ee7-5b295df9891f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pagination component with improved responsive design using container queries.
	- Pagination layout now adapts fluidly to varying screen sizes, displaying three equal columns on wider screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->