### PR TITLE
NEO-2385 FIX: menu not accessible by keyboard inside Table Header

### DIFF
--- a/src/components/Drawer/Drawer.test.jsx
+++ b/src/components/Drawer/Drawer.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { vi } from "vitest";
 

--- a/src/components/Drawer/Drawer.test.jsx
+++ b/src/components/Drawer/Drawer.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { vi } from "vitest";
 
@@ -56,14 +56,21 @@ describe("Drawer", () => {
 			render(<Drawer open={true} title="drawer title" />);
 
 			const drawer = screen.getByRole("dialog");
-			expect(drawer).toHaveClass("neo-drawer--isOpen");
+			await waitFor(
+				() => {
+					expect(drawer).toHaveClass(
+						"neo-drawer neo-drawer--visible neo-drawer--open",
+					);
+				},
+				{ timeout: 5000 },
+			);
 		});
 
 		it("when `open={false}`, a Drawer's contents are _not_ visible", () => {
 			render(<Drawer open={false} title="drawer title" />);
 
 			const drawer = screen.getByRole("dialog");
-			expect(drawer).not.toHaveClass("neo-drawer--isOpen");
+			expect(drawer).not.toHaveClass("neo-drawer--open");
 		});
 	});
 });

--- a/src/components/Drawer/Drawer.test.jsx
+++ b/src/components/Drawer/Drawer.test.jsx
@@ -52,18 +52,11 @@ describe("Drawer", () => {
 	});
 
 	describe("`open` functionality", () => {
-		it("when `open={true}`, a Drawer's contents _are_ visible", async () => {
+		it("when `open={true}`, a Drawer's contents _are_ visible", () => {
 			render(<Drawer open={true} title="drawer title" />);
 
 			const drawer = screen.getByRole("dialog");
-			await waitFor(
-				() => {
-					expect(drawer).toHaveClass(
-						"neo-drawer neo-drawer--visible neo-drawer--open",
-					);
-				},
-				{ timeout: 1000 },
-			);
+			expect(drawer).toHaveClass("neo-drawer neo-drawer--open");
 		});
 
 		it("when `open={false}`, a Drawer's contents are _not_ visible", () => {

--- a/src/components/Drawer/Drawer.test.jsx
+++ b/src/components/Drawer/Drawer.test.jsx
@@ -62,7 +62,7 @@ describe("Drawer", () => {
 						"neo-drawer neo-drawer--visible neo-drawer--open",
 					);
 				},
-				{ timeout: 5000 },
+				{ timeout: 1000 },
 			);
 		});
 

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -33,9 +33,6 @@ type EnforcedAccessibleLabel =
 			"aria-labelledby": string;
 	  };
 
-const OPEN_DELAY = 10;
-const CLOSE_DELAY = 300;
-
 const propsAreAccessible = (
 	title: string | JSX.Element | undefined,
 	actionNodes: React.ReactNode[] | undefined,
@@ -157,38 +154,6 @@ const BasicDrawer = ({
 }) => {
 	const drawerRef = useRef<HTMLDivElement>(null);
 
-	useEffect(() => {
-		const drawer = drawerRef.current;
-		if (!drawer) return;
-
-		if (open) {
-			// Make the drawer visible first
-			drawer.classList.add("neo-drawer--visible");
-
-			// Add the open class after a short delay
-			const openTimer = setTimeout(() => {
-				drawer.classList.add("neo-drawer--open");
-			}, OPEN_DELAY);
-
-			// Cleanup the timer when the component unmounts or open state changes
-			return () => {
-				clearTimeout(openTimer);
-			};
-		}
-		// Remove the open class first
-		drawer.classList.remove("neo-drawer--open");
-
-		// Remove the visible class after the transition duration
-		const closeTimer = setTimeout(() => {
-			drawer.classList.remove("neo-drawer--visible");
-		}, CLOSE_DELAY);
-
-		// Cleanup the timer when the component unmounts or open state changes
-		return () => {
-			clearTimeout(closeTimer);
-		};
-	}, [open]);
-
 	const onKeyDownScrimHandler: KeyboardEventHandler = (
 		e: KeyboardEvent<HTMLButtonElement>,
 	) => {
@@ -206,7 +171,7 @@ const BasicDrawer = ({
 					role="dialog"
 					style={style}
 					aria-labelledby={id}
-					className={clsx("neo-drawer", className)}
+					className={clsx("neo-drawer", open && "neo-drawer--open", className)}
 					{...rest}
 				>
 					<div className="neo-drawer__header">

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -4,6 +4,7 @@ import {
 	type KeyboardEventHandler,
 	useEffect,
 	useId,
+	useRef,
 	useState,
 } from "react";
 
@@ -151,6 +152,26 @@ const BasicDrawer = ({
 	style?: object | undefined;
 	actions?: React.ReactNode[];
 }) => {
+	const drawerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const drawer = drawerRef.current;
+		if (!drawer) return;
+		if (open) {
+			// Make the drawer visible first
+			drawer.classList.add("neo-drawer--visible");
+
+			// After a short delay, apply the transformation to slide it in
+			setTimeout(() => {
+				drawer.classList.add("neo-drawer--open");
+			}, 10);
+		} else {
+			drawer.classList.remove("neo-drawer--open");
+			setTimeout(() => {
+				drawer.classList.remove("neo-drawer--visible");
+			}, 300);
+		}
+	}, [open]);
 	const onKeyDownScrimHandler: KeyboardEventHandler = (
 		e: KeyboardEvent<HTMLButtonElement>,
 	) => {
@@ -163,15 +184,12 @@ const BasicDrawer = ({
 		<div>
 			<FocusLock disabled={!open}>
 				<div
+					ref={drawerRef}
 					onKeyDown={onKeyDownScrimHandler}
 					role="dialog"
 					style={style}
 					aria-labelledby={id}
-					className={clsx(
-						"neo-drawer",
-						open && "neo-drawer--isOpen",
-						className,
-					)}
+					className={clsx("neo-drawer", className)}
 					{...rest}
 				>
 					<div className="neo-drawer__header">

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -33,6 +33,9 @@ type EnforcedAccessibleLabel =
 			"aria-labelledby": string;
 	  };
 
+const OPEN_DELAY = 10;
+const CLOSE_DELAY = 300;
+
 const propsAreAccessible = (
 	title: string | JSX.Element | undefined,
 	actionNodes: React.ReactNode[] | undefined,
@@ -157,21 +160,35 @@ const BasicDrawer = ({
 	useEffect(() => {
 		const drawer = drawerRef.current;
 		if (!drawer) return;
+
 		if (open) {
 			// Make the drawer visible first
 			drawer.classList.add("neo-drawer--visible");
 
-			// After a short delay, apply the transformation to slide it in
-			setTimeout(() => {
+			// Add the open class after a short delay
+			const openTimer = setTimeout(() => {
 				drawer.classList.add("neo-drawer--open");
-			}, 10);
-		} else {
-			drawer.classList.remove("neo-drawer--open");
-			setTimeout(() => {
-				drawer.classList.remove("neo-drawer--visible");
-			}, 300);
+			}, OPEN_DELAY);
+
+			// Cleanup the timer when the component unmounts or open state changes
+			return () => {
+				clearTimeout(openTimer);
+			};
 		}
+		// Remove the open class first
+		drawer.classList.remove("neo-drawer--open");
+
+		// Remove the visible class after the transition duration
+		const closeTimer = setTimeout(() => {
+			drawer.classList.remove("neo-drawer--visible");
+		}, CLOSE_DELAY);
+
+		// Cleanup the timer when the component unmounts or open state changes
+		return () => {
+			clearTimeout(closeTimer);
+		};
 	}, [open]);
+
 	const onKeyDownScrimHandler: KeyboardEventHandler = (
 		e: KeyboardEvent<HTMLButtonElement>,
 	) => {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -4,7 +4,6 @@ import {
 	type KeyboardEventHandler,
 	useEffect,
 	useId,
-	useRef,
 	useState,
 } from "react";
 
@@ -152,8 +151,6 @@ const BasicDrawer = ({
 	style?: object | undefined;
 	actions?: React.ReactNode[];
 }) => {
-	const drawerRef = useRef<HTMLDivElement>(null);
-
 	const onKeyDownScrimHandler: KeyboardEventHandler = (
 		e: KeyboardEvent<HTMLButtonElement>,
 	) => {
@@ -166,7 +163,6 @@ const BasicDrawer = ({
 		<div>
 			<FocusLock disabled={!open}>
 				<div
-					ref={drawerRef}
 					onKeyDown={onKeyDownScrimHandler}
 					role="dialog"
 					style={style}

--- a/src/components/Drawer/Drawer_shim.css
+++ b/src/components/Drawer/Drawer_shim.css
@@ -6,16 +6,19 @@
 	width: 20rem;
 	max-height: 100vh;
 	max-width: 80%;
-
+	display: none;
 	transition: all 0.3s ease-in-out;
 	transform: translate(20rem);
-	display: flex;
 	flex-direction: column;
 	z-index: 1000;
 	background-color: var(--sheet-background);
 }
 
-.neo-drawer--isOpen {
+.neo-drawer--visible {
+	display: flex;
+}
+
+.neo-drawer--open {
 	transform: translate(0);
 	box-shadow: 0px 8px 16px var(--sheet-shadow);
 }

--- a/src/components/Drawer/Drawer_shim.css
+++ b/src/components/Drawer/Drawer_shim.css
@@ -7,20 +7,21 @@
 	max-height: 100vh;
 	max-width: 80%;
 	display: none;
-	transition: all 0.3s ease-in-out;
+	transition: all 0.3s ease-in-out allow-discrete;
 	transform: translate(20rem);
 	flex-direction: column;
 	z-index: 1000;
 	background-color: var(--sheet-background);
 }
 
-.neo-drawer--visible {
-	display: flex;
-}
-
 .neo-drawer--open {
+	display: flex;
 	transform: translate(0);
 	box-shadow: 0px 8px 16px var(--sheet-shadow);
+
+	@starting-style {
+		transform: translate(20rem);
+	}
 }
 
 .neo-drawer__scrim {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 import ClickAwayListener from "react-click-away-listener";
 
+import { Tooltip } from "components/Tooltip";
 import {
 	handleBlurEvent,
 	handleButtonKeyDownEvent,
@@ -74,7 +75,7 @@ export const Menu = forwardRef(
 			closeOnSelect = true,
 			defaultIsOpen = false,
 			itemAlignment = "left",
-			menuRootElement,
+			menuRootElement: menuRootElementOriginal,
 			onMenuClose = () => null,
 			openOnHover = false,
 			positionToToggle = "below",
@@ -218,6 +219,11 @@ export const Menu = forwardRef(
 		type MenuButtonOnClickEventType = HTMLButtonElement & HTMLDivElement;
 
 		const menuButton = useMemo(() => {
+			let menuRootElement = menuRootElementOriginal;
+			if (menuRootElementOriginal.type === Tooltip) {
+				menuRootElement = menuRootElementOriginal.props
+					.children as React.ReactElement;
+			}
 			const buttonProps = {
 				...menuRootElement.props,
 
@@ -248,8 +254,12 @@ export const Menu = forwardRef(
 				},
 				ref: toggleRef,
 			};
-			return cloneElement(menuRootElement, buttonProps);
-		}, [menuRootElement, toggleRef, isOpen, menuIndexes, openOnHover]);
+			const button = cloneElement(menuRootElement, buttonProps);
+			if (menuRootElementOriginal.type === Tooltip) {
+				return cloneElement(menuRootElementOriginal, { children: button });
+			}
+			return button;
+		}, [menuRootElementOriginal, toggleRef, isOpen, menuIndexes, openOnHover]);
 
 		const menuContext: MenuContextType = {
 			closeOnSelect,

--- a/src/components/Menu/helpers/helpers.test.jsx
+++ b/src/components/Menu/helpers/helpers.test.jsx
@@ -8,15 +8,145 @@ import { SubMenu } from "../SubMenu";
 import {
 	addIdToChildren,
 	buildMenuIndexes,
+	flattenChildren,
 	getContentCss,
 	layoutChildren,
 } from "./";
-
 const menuHelpersLogger = log.getLogger("menu-helpers");
 menuHelpersLogger.disableAll();
 
 describe("Menu helper methods", () => {
+	describe("flattenChildren", () => {
+		it("returns empty fragment with an empty fragment", () => {
+			const children = <></>;
+			expect(flattenChildren(children)).toEqual(children);
+		});
+		it("returns empty array with empty array", () => {
+			const children = [];
+			const expected = <></>;
+			expect(flattenChildren(children)).toEqual(expected);
+		});
+		it("returns single child wrapped inside fragment", () => {
+			const children = <MenuItem id="1">View</MenuItem>;
+			expect(flattenChildren(children)).toMatchInlineSnapshot(`
+				<React.Fragment>
+				  <MenuItem
+				    id="1"
+				  >
+				    View
+				  </MenuItem>
+				</React.Fragment>
+			`);
+		});
+		it("returns the same children wrapped inside fragment", () => {
+			const children = (
+				<>
+					<MenuItem key="1" id="1">
+						View
+					</MenuItem>
+					<MenuItem key="2" id="2">
+						Edit
+					</MenuItem>
+					<MenuItem key="3" id="3">
+						Delete
+					</MenuItem>
+				</>
+			);
+			expect(flattenChildren(children)).toMatchInlineSnapshot(`
+				<React.Fragment>
+				  <MenuItem
+				    id="1"
+				  >
+				    View
+				  </MenuItem>
+				  <MenuItem
+				    id="2"
+				  >
+				    Edit
+				  </MenuItem>
+				  <MenuItem
+				    id="3"
+				  >
+				    Delete
+				  </MenuItem>
+				</React.Fragment>
+			`);
+		});
+		it("should flatten children inside fragment", () => {
+			const children = [
+				<MenuItem key="1" id="1">
+					View
+				</MenuItem>,
+				<>
+					<MenuItem key="2-1" id="2-1">
+						View
+					</MenuItem>
+					<MenuItem key="2-2" id="2-2">
+						Edit
+					</MenuItem>
+					<MenuItem key="2-3" id="2-3">
+						Delete
+					</MenuItem>
+				</>,
+			];
+			expect(flattenChildren(children).props.children.length).toEqual(4);
+			expect(flattenChildren(children)).toMatchInlineSnapshot(`
+				<React.Fragment>
+				  <MenuItem
+				    id="1"
+				  >
+				    View
+				  </MenuItem>
+				  <MenuItem
+				    id="2-1"
+				  >
+				    View
+				  </MenuItem>
+				  <MenuItem
+				    id="2-2"
+				  >
+				    Edit
+				  </MenuItem>
+				  <MenuItem
+				    id="2-3"
+				  >
+				    Delete
+				  </MenuItem>
+				</React.Fragment>
+			`);
+		});
+		it("should not flatten SubMenu", () => {
+			const children = (
+				<>
+					<MenuItem key="1" id="1">
+						View
+					</MenuItem>
+					,
+					<SubMenu
+						key="2"
+						id="2"
+						menuRootElement={<MenuItem id="20">File</MenuItem>}
+					>
+						<MenuItem id="21">View</MenuItem>
+						<MenuItem id="22">Edit</MenuItem>
+						<MenuItem id="23">Delete</MenuItem>
+					</SubMenu>
+					,
+					<MenuItem key="3" id="3">
+						Help
+					</MenuItem>
+					,
+				</>
+			);
+			expect(flattenChildren(children).props.children.length).toEqual(3);
+		});
+	});
+
 	describe("addIdToChildren", () => {
+		it("should return empty array with empty fragment", () => {
+			const children = <></>;
+			expect(addIdToChildren(children)).toEqual([]);
+		});
 		it("should do nothing when child is not menu item or sub menu", () => {
 			const children = <MenuSeparator />;
 			expect(addIdToChildren(children).length).toBe(1);
@@ -51,6 +181,10 @@ describe("Menu helper methods", () => {
 	});
 
 	describe("buildMenuIndexes", () => {
+		it("should return empty array with empty fragment", () => {
+			const children = <></>;
+			expect(buildMenuIndexes(children)).toEqual([]);
+		});
 		it("should return empty array with empty children", () => {
 			const children = [];
 			expect(buildMenuIndexes(children)).toEqual([]);

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -931,7 +931,7 @@ describe("Table", () => {
 					ascDurationValues = getDurationValues(queryAllByRole);
 					expect(ascDurationValues).not.toEqual([...durationValues]);
 				},
-				{ timeout: 10000 },
+				{ timeout: 5000 },
 			);
 			expect(ascDurationValues).toEqual(
 				[...ascDurationValues].sort((a, b) => a - b),
@@ -955,13 +955,13 @@ describe("Table", () => {
 					descDurationValues = getDurationValues(queryAllByRole);
 					expect(descDurationValues).not.toEqual([...ascDurationValues]);
 				},
-				{ timeout: 10000 },
+				{ timeout: 5000 },
 			);
 
 			expect(descDurationValues).toEqual(
 				[...descDurationValues].sort((a, b) => b - a),
 			);
-		}, 15000);
+		}, 10000);
 	});
 	describe("sort and filter functionality", () => {
 		let renderResult;

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -946,7 +946,7 @@ describe("Table", () => {
 			expect(descDurationValues).toEqual(
 				[...descDurationValues].sort((a, b) => b - a),
 			);
-		}, 10000);
+		}, 5000);
 	});
 	describe("sort and filter functionality", () => {
 		let renderResult;
@@ -1049,14 +1049,8 @@ describe("Table", () => {
 			const menuItems = queryAllByRole("menuitem");
 			expect(menuItems).toHaveLength(4);
 			await user.click(queryAllByRole("menuitem")[3]);
-
-			await waitFor(
-				() => {
-					expect(getAllByRole("dialog")[1]).toHaveClass(
-						"neo-drawer neo-drawer--open",
-					);
-				},
-				{ timeout: 5000 },
+			expect(getAllByRole("dialog")[1]).toHaveClass(
+				"neo-drawer neo-drawer--open",
 			);
 
 			let nameInput = getAllByRole("textbox")[1];
@@ -1120,7 +1114,7 @@ describe("Table", () => {
 				"tr th div[role='menuitem'] span[role='img']",
 			);
 			expect(checkIcon).toBeNull();
-		}, 10000);
+		});
 
 		it("toggles column visibility via toolbar Filter Icon Button", async () => {
 			const { container, getAllByRole, getByLabelText, getAllByLabelText } =

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -784,14 +784,7 @@ describe("Table", () => {
 			await user.click(dateColumnFilterMenuItems[3]);
 
 			let columnFilterDrawer = queryAllByRole("dialog")[1];
-			await waitFor(
-				() => {
-					expect(columnFilterDrawer).toHaveClass(
-						"neo-drawer neo-drawer--visible neo-drawer--open",
-					);
-				},
-				{ timeout: 5000 },
-			);
+			expect(columnFilterDrawer).toHaveClass("neo-drawer neo-drawer--open");
 
 			// Wait for the input box to appear
 			let dateInput = await waitFor(() =>
@@ -836,15 +829,7 @@ describe("Table", () => {
 			await user.click(dateColumnFilterMenuItems[3]);
 
 			columnFilterDrawer = queryAllByRole("dialog")[1];
-			await waitFor(
-				() => {
-					expect(columnFilterDrawer).toHaveClass(
-						"neo-drawer neo-drawer--visible neo-drawer--open",
-					);
-				},
-				{ timeout: 5000 },
-			);
-
+			expect(columnFilterDrawer).toHaveClass("neo-drawer neo-drawer--open");
 			// Wait for the input box to appear
 			dateInput = await waitFor(() =>
 				within(columnFilterDrawer).getByRole("textbox"),
@@ -1158,16 +1143,9 @@ describe("Table", () => {
 			);
 
 			await user.click(columnFilterButton);
-
-			await waitFor(
-				() => {
-					expect(getAllByRole("dialog")[0]).toHaveClass(
-						"neo-drawer neo-drawer--visible neo-drawer--open",
-					);
-				},
-				{ timeout: 5000 },
+			expect(getAllByRole("dialog")[0]).toHaveClass(
+				"neo-drawer  neo-drawer--open",
 			);
-
 			const nameCheckbox = getByLabelText(FilledFields.columns[0].Header);
 			expect(nameCheckbox).toBeChecked();
 
@@ -1179,7 +1157,7 @@ describe("Table", () => {
 			)[0];
 			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
-		}, 10000);
+		});
 
 		it("allows user to predefine hidden rows", async () => {
 			// find the "Long Text" `<th>` element

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -784,7 +784,14 @@ describe("Table", () => {
 			await user.click(dateColumnFilterMenuItems[3]);
 
 			let columnFilterDrawer = queryAllByRole("dialog")[1];
-			expect(columnFilterDrawer).toHaveClass("neo-drawer neo-drawer--isOpen");
+			await waitFor(
+				() => {
+					expect(columnFilterDrawer).toHaveClass(
+						"neo-drawer neo-drawer--visible neo-drawer--open",
+					);
+				},
+				{ timeout: 5000 },
+			);
 
 			// Wait for the input box to appear
 			let dateInput = await waitFor(() =>
@@ -829,7 +836,14 @@ describe("Table", () => {
 			await user.click(dateColumnFilterMenuItems[3]);
 
 			columnFilterDrawer = queryAllByRole("dialog")[1];
-			expect(columnFilterDrawer).toHaveClass("neo-drawer neo-drawer--isOpen");
+			await waitFor(
+				() => {
+					expect(columnFilterDrawer).toHaveClass(
+						"neo-drawer neo-drawer--visible neo-drawer--open",
+					);
+				},
+				{ timeout: 5000 },
+			);
 
 			// Wait for the input box to appear
 			dateInput = await waitFor(() =>
@@ -947,7 +961,7 @@ describe("Table", () => {
 			expect(descDurationValues).toEqual(
 				[...descDurationValues].sort((a, b) => b - a),
 			);
-		});
+		}, 15000);
 	});
 	describe("sort and filter functionality", () => {
 		let renderResult;
@@ -1042,7 +1056,7 @@ describe("Table", () => {
 			expect(firstColumnSortButton).toBeVisible();
 
 			expect(getAllByRole("dialog")[0]).not.toHaveClass(
-				"neo-drawer neo-drawer--isOpen",
+				"neo-drawer neo-drawer--open",
 			);
 
 			await user.click(firstColumnSortButton);
@@ -1051,8 +1065,13 @@ describe("Table", () => {
 			expect(menuItems).toHaveLength(4);
 			await user.click(queryAllByRole("menuitem")[3]);
 
-			expect(getAllByRole("dialog")[1]).toHaveClass(
-				"neo-drawer neo-drawer--isOpen",
+			await waitFor(
+				() => {
+					expect(getAllByRole("dialog")[1]).toHaveClass(
+						"neo-drawer neo-drawer--visible neo-drawer--open",
+					);
+				},
+				{ timeout: 5000 },
 			);
 
 			let nameInput = getAllByRole("textbox")[1];
@@ -1116,7 +1135,7 @@ describe("Table", () => {
 				"tr th div[role='menuitem'] span[role='img']",
 			);
 			expect(checkIcon).toBeNull();
-		});
+		}, 10000);
 
 		it("toggles column visibility via toolbar Filter Icon Button", async () => {
 			const { container, getAllByRole, getByLabelText, getAllByLabelText } =
@@ -1135,13 +1154,18 @@ describe("Table", () => {
 			);
 
 			expect(getAllByRole("dialog")[0]).not.toHaveClass(
-				"neo-drawer neo-drawer--isOpen",
+				"neo-drawer neo-drawer--open",
 			);
 
 			await user.click(columnFilterButton);
 
-			expect(getAllByRole("dialog")[0]).toHaveClass(
-				"neo-drawer neo-drawer--isOpen",
+			await waitFor(
+				() => {
+					expect(getAllByRole("dialog")[0]).toHaveClass(
+						"neo-drawer neo-drawer--visible neo-drawer--open",
+					);
+				},
+				{ timeout: 5000 },
 			);
 
 			const nameCheckbox = getByLabelText(FilledFields.columns[0].Header);

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -1068,7 +1068,7 @@ describe("Table", () => {
 			await waitFor(
 				() => {
 					expect(getAllByRole("dialog")[1]).toHaveClass(
-						"neo-drawer neo-drawer--visible neo-drawer--open",
+						"neo-drawer neo-drawer--open",
 					);
 				},
 				{ timeout: 5000 },
@@ -1179,7 +1179,7 @@ describe("Table", () => {
 			)[0];
 			await user.click(applyButton);
 			expect(firstColumnSortButton).not.toBeVisible();
-		});
+		}, 10000);
 
 		it("allows user to predefine hidden rows", async () => {
 			// find the "Long Text" `<th>` element


### PR DESCRIPTION
[Table](https://deploy-preview-547--neo-react-library-storybook.netlify.app/?path=/story/components-table--advanced-filtering-and-sorting)
[Drawer](https://deploy-preview-547--neo-react-library-storybook.netlify.app/?path=/story/components-drawer--basic-drawer)
[Link to original PR where these problems were reported by @Justin-Avaya ](https://github.com/avaya-dux/neo-react-library/pull/530#issuecomment-2344650000)
**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

`@avaya-dux/dux-design`: Fix the two accessibility issues reported in previous pr;
- Menus on table header do not open with keyboard
- Can not reach the bottom menu item with keyboard

`@avaya-dux/dux-devs`: 
- Allow menu items wrapped by React Fragment
- Tolerate Tooltip wrapping MenuButton



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the `Drawer` component for improved visibility and animation handling, ensuring a smoother user experience.
  
- **Bug Fixes**
	- Enhanced the robustness of tests for the `Drawer` and `Table` components to better reflect UI state changes.

- **Tests**
	- Updated test cases for the `Drawer` component to validate visibility states comprehensively, utilizing asynchronous checks for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->