### PR TITLE
DEV ONLY, Paginatoin // update storybook docs

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -21,6 +21,12 @@ const meta: Meta<typeof Pagination> = {
 		// don't show the id prop
 		id: { table: { disable: true } },
 
+		backIconButtonText: { table: { category: "translations" } },
+		nextIconButtonText: { table: { category: "translations" } },
+		pagesText: { table: { category: "translations" } },
+		goToPageText: { table: { category: "translations" } },
+		itemsPerPageLabel: { table: { category: "translations" } },
+
 		// don't show JS/React specific props
 		onPageChange: { table: { disable: true } },
 		onItemsPerPageChange: { table: { disable: true } },
@@ -28,13 +34,6 @@ const meta: Meta<typeof Pagination> = {
 		leftNode: { table: { disable: true } },
 		centerNode: { table: { disable: true } },
 		rightNode: { table: { disable: true } },
-
-		// don't show translations
-		backIconButtonText: { table: { disable: true } },
-		nextIconButtonText: { table: { disable: true } },
-		pagesText: { table: { disable: true } },
-		goToPageText: { table: { disable: true } },
-		itemsPerPageLabel: { table: { disable: true } },
 	},
 };
 export default meta;

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -43,7 +43,6 @@ export const Pagination = ({
 	currentPageIndex,
 	itemCount,
 	itemsPerPage,
-	itemsPerPageLabel,
 	itemsPerPageOptions = [20, 50, 100],
 
 	alwaysShowPagination,
@@ -58,6 +57,7 @@ export const Pagination = ({
 	nextIconButtonText = "next",
 	pagesText = "pages",
 	goToPageText = "Go to page",
+	itemsPerPageLabel = "Rows",
 
 	// default overrides
 	centerNode,


### PR DESCRIPTION
[Link to updated Pagination stories](https://deploy-preview-559--neo-react-library-storybook.netlify.app/?path=/docs/components-pagination--docs)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

[Harpreet could not figure out](https://teams.microsoft.com/l/message/19:0c670e994bea49d3b3fd053761191c8c@thread.tacv2/1727953446320?tenantId=04a2636c-326d-48ff-93f8-709875bd3aa9&groupId=172efbe2-ae64-4652-8f08-de11e90b9230&parentMessageId=1727953446320&teamName=NEO%20Design%20System&channelName=Neo%20-%20Make%20New%20Requests&createdTime=1727953446320) our translations for the Pagination. I have thus updated our storybook docs to make it obvious. 

**EXAMPLE IMAGE(S):**
![Screenshot 2024-10-07 at 12 46 31](https://github.com/user-attachments/assets/ba818ca1-5c1a-4ba0-9726-868ac2ca6b67)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added default value for `itemsPerPageLabel` in the Pagination component, simplifying usage.
	- Introduced new translation properties in Storybook for better documentation of the Pagination component.

- **Bug Fixes**
	- Removed previous configuration that disabled the display of translation properties in Storybook, enhancing visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->