### PR TITLE
DEV ONLY // add missing callback to Table internals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -472,6 +472,46 @@ describe("Table", () => {
 				0,
 			);
 		});
+
+		it("utilizes the same callback when selecting or deselecting rows via the header checkbox and the 'clear-row' button", async () => {
+			const allRowsToggledOnText = "All rows were toggled ON"; // from story
+			const allRowsToggledOffText = "All rows were toggled OFF"; // from story
+			render(<PreSelectedRows />);
+
+			const toggleItemsCheckbox = screen.getByLabelText(
+				FilledFields.translations.header.selectPage,
+			);
+
+			// no selections, no toggle messages
+			expect(screen.queryAllByText(allRowsToggledOnText)).toHaveLength(0);
+			expect(screen.queryAllByText(allRowsToggledOffText)).toHaveLength(0);
+
+			// select all, one "on" message
+			const selectAllItemsButton = screen.getByText(
+				FilledFields.translations.header.selectAll,
+			);
+			await user.click(selectAllItemsButton);
+			expect(screen.queryAllByText(allRowsToggledOnText)).toHaveLength(1);
+			expect(screen.queryAllByText(allRowsToggledOffText)).toHaveLength(0);
+
+			// deselect all rows, one "off" message
+			await user.click(toggleItemsCheckbox);
+			expect(screen.queryAllByText(allRowsToggledOnText)).toHaveLength(1);
+			expect(screen.queryAllByText(allRowsToggledOffText)).toHaveLength(1);
+
+			// select all rows, two "on" messages
+			await user.click(toggleItemsCheckbox);
+			expect(screen.queryAllByText(allRowsToggledOnText)).toHaveLength(2);
+			expect(screen.queryAllByText(allRowsToggledOffText)).toHaveLength(1);
+
+			// deselect all rows, two "off" messages
+			const deselectAllItemsButton = screen.getByText(
+				FilledFields.translations.header.clearAll,
+			);
+			await user.click(deselectAllItemsButton);
+			expect(screen.queryAllByText(allRowsToggledOnText)).toHaveLength(2);
+			expect(screen.queryAllByText(allRowsToggledOffText)).toHaveLength(2);
+		});
 	});
 
 	describe("toolbar functionality", () => {
@@ -948,6 +988,7 @@ describe("Table", () => {
 			);
 		}, 10000);
 	});
+
 	describe("sort and filter functionality", () => {
 		let renderResult;
 

--- a/src/components/Table/TableComponents/TableBody.tsx
+++ b/src/components/Table/TableComponents/TableBody.tsx
@@ -67,6 +67,7 @@ export const TableBody: TableBodyComponentType = ({
 				<>
 					{showRowSelectionHelper && (
 						<ClearSelectionRow
+							handleRowToggled={handleRowToggled}
 							instance={instance}
 							selectableRows={selectableRows}
 							translations={translations}


### PR DESCRIPTION
[Link to updated Table story](https://deploy-preview-563--neo-react-library-storybook.netlify.app/?path=/story/components-table--pre-selected-rows)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

[Bhavesh found a bug](https://teams.microsoft.com/l/message/19:0c670e994bea49d3b3fd053761191c8c@thread.tacv2/1728891430456?tenantId=04a2636c-326d-48ff-93f8-709875bd3aa9&groupId=172efbe2-ae64-4652-8f08-de11e90b9230&parentMessageId=1728891430456&teamName=NEO%20Design%20System&channelName=Neo%20-%20Make%20New%20Requests&createdTime=1728891430456). This one liner (plus added unit tests) fixes it. 

`@avaya-dux/dux-devs`: The usual


**EXAMPLE FUNCTIONALITY GIF:**
![2024-10-14 15 35 32](https://github.com/user-attachments/assets/f163f06b-4a41-43ff-9eb0-d131b8f4f779)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version to 1.3.7 for the project.
	- Enhanced row selection functionality in the table component, allowing users to clear or select all enabled rows.
- **Bug Fixes**
	- Improved test coverage for row selection actions, ensuring consistent callback behavior across UI elements.
- **Tests**
	- Added a new test case for verifying row selection functionality in the table component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->