### PR TITLE
React TextInput component:  allow label with icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -22,6 +22,20 @@ export const Default = () => {
 	);
 };
 
+export const LabelWithIcon = () => {
+	return (
+		<Form>
+			<TextInput
+				label={
+					<span style={{ display: "flex", alignItems: "flex-end", gap: "4px" }}>
+						Workflow ID
+						<Icon icon="info" aria-label="workflow id" size="sm" />
+					</span>
+				}
+			/>
+		</Form>
+	);
+};
 export const DifferentHTMLOutputExamples = () => {
 	return (
 		<section>

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -30,7 +30,7 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
 	error?: boolean;
 	helperText?: string;
 	inline?: boolean;
-	label?: string;
+	label?: ReactNode;
 	placeholder?: string;
 	readOnly?: boolean;
 	required?: boolean;


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-569--neo-react-library-storybook.netlify.app/?path=/story/components-text-input--label-with-icon)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY (should be brief, one sentence if possible)

`@avaya-dux/dux-design`:
`@avaya-dux/dux-devs`: 

- Icon allowed per request


<img width="478" alt="Screenshot 2024-10-21 at 12 34 53 PM" src="https://github.com/user-attachments/assets/9c5b153a-22a9-4844-8636-d14b596966ac">
