### PR TITLE
NEO-2457  Allow icon next to the label in both TextInput and Switch react components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@avaya/neo-react",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "This is the React version of the shared library called 'NEO' built by Avaya",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"repository": "github:avaya-dux/neo-react-library",

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,0 +1,36 @@
+import { Icon } from "components";
+import { Tooltip, type TooltipPosition } from "components";
+import type { IconNamesType } from "utils";
+import "./Label_shim.css";
+type IconProps = {
+	iconType: IconNamesType;
+	iconAriaLabel: string;
+	iconTooltipPosition: TooltipPosition;
+	iconTooltipText: string;
+};
+
+export type LabelProps = {
+	htmlFor: string;
+	text: string;
+	icon?: IconProps;
+};
+
+export type ExternalLabelProps = Omit<LabelProps, "htmlFor">;
+
+export const Label = ({ text: label, htmlFor: id, icon }: LabelProps) => {
+	return icon === undefined ? (
+		<label htmlFor={id}>{label}</label>
+	) : (
+		<div className="neo-form__label-with-icon">
+			<label htmlFor={id}>{label}</label>
+			<Tooltip label={icon.iconTooltipText} position={icon.iconTooltipPosition}>
+				<Icon
+					tabIndex={0}
+					icon={icon.iconType}
+					aria-label={icon.iconAriaLabel}
+					size="sm"
+				/>
+			</Tooltip>
+		</div>
+	);
+};

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,7 +2,8 @@ import { Icon } from "components";
 import { Tooltip, type TooltipPosition } from "components";
 import type { IconNamesType } from "utils";
 import "./Label_shim.css";
-type IconProps = {
+import { useMemo } from "react";
+export type LabelIconProps = {
 	iconType: IconNamesType;
 	iconAriaLabel: string;
 	iconTooltipPosition: TooltipPosition;
@@ -11,18 +12,33 @@ type IconProps = {
 
 export type LabelProps = {
 	htmlFor: string;
-	text: string;
-	icon?: IconProps;
+	text?: string;
+	className?: string;
+	children?: React.ReactNode;
+	icon?: LabelIconProps;
 };
 
 export type ExternalLabelProps = Omit<LabelProps, "htmlFor">;
 
-export const Label = ({ text: label, htmlFor: id, icon }: LabelProps) => {
+export const Label = ({
+	text: label,
+	htmlFor: id,
+	className,
+	children,
+	icon,
+}: LabelProps) => {
+	const justLabel = useMemo(() => {
+		return (
+			<label htmlFor={id} className={className}>
+				{label || children}
+			</label>
+		);
+	}, [id, label, className, children]);
 	return icon === undefined ? (
-		<label htmlFor={id}>{label}</label>
+		justLabel
 	) : (
 		<div className="neo-form__label-with-icon">
-			<label htmlFor={id}>{label}</label>
+			{justLabel}
 			<Tooltip label={icon.iconTooltipText} position={icon.iconTooltipPosition}>
 				<Icon
 					tabIndex={0}

--- a/src/components/Label/Label_shim.css
+++ b/src/components/Label/Label_shim.css
@@ -1,7 +1,6 @@
 .neo-input-group .neo-form__label-with-icon {
 	display: flex;
 	align-items: center;
-	gap: 2px;
 	padding-bottom: 4px;
 
 	/* TextInput label */
@@ -11,6 +10,10 @@
 		font-size: 12px;
 		font-weight: 400;
 		line-height: 16px;
+	}
+
+	div.neo-tooltip {
+		padding-inline-start: 8px;
 	}
 
 	/* Switch label */

--- a/src/components/Label/Label_shim.css
+++ b/src/components/Label/Label_shim.css
@@ -1,0 +1,42 @@
+.neo-input-group .neo-form__label-with-icon {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding-bottom: 4px;
+
+	label {
+		letter-spacing: 0;
+		color: var(--input-label-color);
+		font-size: 12px;
+		font-weight: 400;
+		line-height: 16px;
+	}
+}
+
+.neo-form .neo-form-control > .neo-input-group .neo-form__label-with-icon,
+.neo-form
+	.neo-form-control--required
+	> .neo-input-group
+	.neo-form__label-with-icon {
+	> label {
+		padding-bottom: unset;
+	}
+
+	div {
+		span {
+			display: flex;
+			align-items: center;
+		}
+	}
+}
+
+.neo-form
+	.neo-form-control--required
+	> .neo-input-group
+	.neo-form__label-with-icon
+	> label:after {
+	color: var(--input-asterix-color);
+	content: "*";
+	display: inline-block;
+	padding-inline-start: 2px;
+}

--- a/src/components/Label/Label_shim.css
+++ b/src/components/Label/Label_shim.css
@@ -4,12 +4,30 @@
 	gap: 2px;
 	padding-bottom: 4px;
 
+	/* TextInput label */
 	label {
 		letter-spacing: 0;
 		color: var(--input-label-color);
 		font-size: 12px;
 		font-weight: 400;
 		line-height: 16px;
+	}
+
+	/* Switch label */
+	label.neo-switch {
+		color: var(--input-label-color);
+		min-width: 32px;
+		height: 20px;
+		padding-inline-start: 27px;
+		line-height: 20px;
+		font-size: 14px;
+		display: flex;
+		position: relative;
+		/* center align icon */
+		& + div span {
+			display: flex;
+			align-items: center;
+		}
 	}
 }
 

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -1,0 +1,2 @@
+export * from "./Label";
+export * from "./useLabel";

--- a/src/components/Label/useLabel.tsx
+++ b/src/components/Label/useLabel.tsx
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { type ExternalLabelProps, Label } from "./Label";
+
+export const useLabel = (
+	label: string | ExternalLabelProps,
+	htmlFor: string,
+) => {
+	const labelProps = useMemo(() => {
+		if (typeof label === "string") {
+			return {
+				text: label,
+				htmlFor,
+			};
+		}
+		return { ...label, htmlFor };
+	}, [label, htmlFor]);
+	return useMemo(() => <Label {...labelProps} />, [labelProps]);
+};

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "components/Button";
 import { Form } from "components/Form";
 
+import type { LabelIconProps } from "components/Label";
 import { Switch, type SwitchProps } from "./";
 
 export default {
@@ -21,47 +22,69 @@ const DirectionTemplate: Story<DirectionTemplateProps> = ({
 	const longText =
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean rhoncus non elit eu mollis.";
 
+	const labelIcon = {
+		iconType: "info",
+		iconAriaLabel: "Info",
+		iconTooltipPosition: "auto",
+		iconTooltipText: "This is a tooltip",
+	} as LabelIconProps;
 	return (
-		<section style={{ width: 200 }} dir={dir}>
-			<Switch onChange={(_e, checked) => alert(`Checked -> ${checked}`)}>
-				Alert on toggle
-			</Switch>
+		<main>
+			<h3>Switches</h3>
+			<section style={{ width: 200 }} dir={dir}>
+				<Switch onChange={(_e, checked) => alert(`Checked -> ${checked}`)}>
+					Alert on toggle
+				</Switch>
 
-			<Switch
-				checked={checked}
-				onChange={(_e, updatedChecked) => setChecked(updatedChecked)}
-			>
-				Controlled Switch
-			</Switch>
+				<Switch
+					checked={checked}
+					onChange={(_e, updatedChecked) => setChecked(updatedChecked)}
+				>
+					Controlled Switch
+				</Switch>
+				<Switch
+					checked={checked}
+					onChange={(_e, updatedChecked) => setChecked(updatedChecked)}
+				>
+					Controlled Switch
+				</Switch>
 
-			<Switch defaultChecked>Default Checked</Switch>
+				<Switch defaultChecked>Default Checked</Switch>
 
-			<Switch disabled>Disabled Unchecked</Switch>
-			<Switch disabled defaultChecked>
-				Disabled Checked
-			</Switch>
-			<Switch defaultChecked dir="rtl">
-				Label fixed on left
-			</Switch>
-			<Switch multiline>
-				Long multiline text controlled by parent: {longText}
-			</Switch>
-			<Switch multiline dir="rtl">
-				Long multiline text fixed on left: {longText}
-			</Switch>
-			<Switch multiline dir="rtl">
-				multiline 1 text fixed on left
-				<br />
-				multiline 2 <br />
-				multiline 3
-			</Switch>
-			<Switch multiline>
-				multiline 1 text controlled by parent
-				<br />
-				multiline 2 <br />
-				multiline 3
-			</Switch>
-		</section>
+				<Switch disabled>Disabled Unchecked</Switch>
+				<Switch disabled defaultChecked>
+					Disabled Checked
+				</Switch>
+				<Switch defaultChecked dir="rtl">
+					Label fixed on left
+				</Switch>
+				<Switch multiline>
+					Long multiline text controlled by parent: {longText}
+				</Switch>
+				<Switch multiline dir="rtl">
+					Long multiline text fixed on left: {longText}
+				</Switch>
+				<Switch multiline dir="rtl">
+					multiline 1 text fixed on left
+					<br />
+					multiline 2 <br />
+					multiline 3
+				</Switch>
+				<Switch multiline>
+					multiline 1 text controlled by parent
+					<br />
+					multiline 2 <br />
+					multiline 3
+				</Switch>
+			</section>
+			<h3>Switches with Icons</h3>
+			<section style={{ width: 200 }} dir={dir}>
+				<Switch labelIcon={labelIcon}>With Icon</Switch>
+				<Switch labelIcon={labelIcon} dir="rtl">
+					With Icon
+				</Switch>
+			</section>
+		</main>
 	);
 };
 

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -3,6 +3,7 @@ import { useId } from "react";
 
 import { NeoInputWrapper } from "components/NeoInputWrapper";
 
+import { Label } from "components/Label";
 import type { SwitchProps } from "./SwitchTypes";
 
 /**
@@ -33,6 +34,7 @@ export const Switch = ({
 	multiline,
 	onChange,
 	dir,
+	labelIcon,
 	...rest
 }: SwitchProps) => {
 	const generatedId = useId();
@@ -50,13 +52,14 @@ export const Switch = ({
 			required={required}
 			dir={dir}
 		>
-			<label
+			<Label
 				className={clsx(
 					"neo-switch",
 					multiline && "neo-switch--multiline",
 					disabled && "neo-switch--disabled",
 				)}
 				htmlFor={id}
+				icon={labelIcon}
 			>
 				<input
 					id={id}
@@ -74,7 +77,7 @@ export const Switch = ({
 				) : (
 					children
 				)}
-			</label>
+			</Label>
 		</NeoInputWrapper>
 	);
 };

--- a/src/components/Switch/SwitchTypes.ts
+++ b/src/components/Switch/SwitchTypes.ts
@@ -1,3 +1,4 @@
+import type { LabelIconProps } from "components/Label";
 import type {
 	ChangeEvent,
 	ChangeEventHandler,
@@ -20,4 +21,5 @@ export interface SwitchProps
 	multiline?: boolean;
 	onChange?: ChangeEventHandler<HTMLInputElement> | SwitchChangeHandler;
 	children?: ReactNode;
+	labelIcon?: LabelIconProps;
 }

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -33,34 +33,54 @@ export const LabelWithIcon = () => {
 			iconTooltipText: "This is the ID of the workflow.",
 		},
 	} as ExternalLabelProps;
+	const [dir, setDir] = useState("ltr");
 	return (
-		<Form>
-			<TextInput label={label} required placeholder="label: required, icon" />
-			<TextInput label={label} placeholder="label: icon" />
+		<>
+			<h3>Direction</h3>
+			<Checkbox
+				onChange={() => setDir(dir === "ltr" ? "rtl" : "ltr")}
+				value={dir}
+			>
+				Check to make TextInput direction RTL
+			</Checkbox>
+			<h3>Label with Icon</h3>
+			<Form dir={dir}>
+				<TextInput label={label} placeholder="label: icon" />
+			</Form>
+			<Checkbox
+				onChange={() => setDir(dir === "ltr" ? "rtl" : "ltr")}
+				value={dir}
+			>
+				Right to Left?
+			</Checkbox>
+			<Form dir={dir}>
+				<TextInput label={label} required placeholder="label: required, icon" />
+				<TextInput label={label} placeholder="label: icon" />
 
-			{/* small size variant */}
-			<TextInput
-				label={label}
-				required
-				isSmall
-				placeholder="input: small, label: required, icon"
-			/>
-			<TextInput
-				label={label}
-				isSmall
-				placeholder="input: small, label: icon"
-			/>
-
-			{/* custom rule */}
-			<div className="container--narrow">
+				{/* small size variant */}
 				<TextInput
 					label={label}
 					required
-					className="custom-rule--narrow"
-					placeholder="customized narrow input"
+					isSmall
+					placeholder="input: small, label: required, icon"
 				/>
-			</div>
-		</Form>
+				<TextInput
+					label={label}
+					isSmall
+					placeholder="input: small, label: icon"
+				/>
+
+				{/* custom rule */}
+				<div className="container--narrow">
+					<TextInput
+						label={label}
+						required
+						className="custom-rule--narrow"
+						placeholder="customized narrow input"
+					/>
+				</div>
+			</Form>
+		</>
 	);
 };
 export const DifferentHTMLOutputExamples = () => {

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -5,7 +5,7 @@ import { Checkbox, Form, Icon } from "components";
 import type { ExternalLabelProps } from "components/Label";
 import { useCallback, useState } from "react";
 import { TextInput, type TextInputProps } from "./TextInput";
-
+import "./TextInput.stories_shim.css";
 export default {
 	title: "Components/Text Input",
 	component: TextInput,
@@ -35,10 +35,31 @@ export const LabelWithIcon = () => {
 	} as ExternalLabelProps;
 	return (
 		<Form>
-			<TextInput label={label} required />
-			<TextInput label={label} />
-			<TextInput label={label} required isSmall />
-			<TextInput label={label} isSmall />
+			<TextInput label={label} required placeholder="label: required, icon" />
+			<TextInput label={label} placeholder="label: icon" />
+
+			{/* small size variant */}
+			<TextInput
+				label={label}
+				required
+				isSmall
+				placeholder="input: small, label: required, icon"
+			/>
+			<TextInput
+				label={label}
+				isSmall
+				placeholder="input: small, label: icon"
+			/>
+
+			{/* custom rule */}
+			<div className="container--narrow">
+				<TextInput
+					label={label}
+					required
+					className="custom-rule--narrow"
+					placeholder="customized narrow input"
+				/>
+			</div>
 		</Form>
 	);
 };

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta } from "@storybook/react";
 
 import { Checkbox, Form, Icon } from "components";
 
+import type { ExternalLabelProps } from "components/Label";
 import { useCallback, useState } from "react";
 import { TextInput, type TextInputProps } from "./TextInput";
 
@@ -22,6 +23,25 @@ export const Default = () => {
 	);
 };
 
+export const LabelWithIcon = () => {
+	const label = {
+		text: "Workflow ID",
+		icon: {
+			iconType: "info",
+			iconAriaLabel: "workflow id",
+			iconTooltipPosition: "auto",
+			iconTooltipText: "This is the ID of the workflow.",
+		},
+	} as ExternalLabelProps;
+	return (
+		<Form>
+			<TextInput label={label} required />
+			<TextInput label={label} />
+			<TextInput label={label} required isSmall />
+			<TextInput label={label} isSmall />
+		</Form>
+	);
+};
 export const DifferentHTMLOutputExamples = () => {
 	return (
 		<section>

--- a/src/components/TextInput/TextInput.stories_shim.css
+++ b/src/components/TextInput/TextInput.stories_shim.css
@@ -1,0 +1,7 @@
+.container--narrow {
+	max-width: 280px;
+}
+.custom-rule--narrow {
+	color: orange;
+	max-width: 250px;
+}

--- a/src/components/TextInput/TextInput.test.jsx
+++ b/src/components/TextInput/TextInput.test.jsx
@@ -18,6 +18,7 @@ const {
 	Disabled,
 	BadAccessibility,
 	TypeSwitch,
+	LabelWithIcon,
 } = composeStories(TextInputStories);
 
 describe("TextInput", () => {
@@ -97,6 +98,25 @@ describe("TextInput", () => {
 
 			beforeEach(() => {
 				renderResult = render(<Default />);
+			});
+
+			it("should render ok", () => {
+				const { container } = renderResult;
+				expect(container).not.toBe(null);
+			});
+
+			it("passes basic axe compliance", async () => {
+				const { container } = renderResult;
+				const results = await axe(container);
+				expect(results).toHaveNoViolations();
+			});
+		});
+
+		describe("LabelWithIcon", () => {
+			let renderResult;
+
+			beforeEach(() => {
+				renderResult = render(<LabelWithIcon />);
 			});
 
 			it("should render ok", () => {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -226,10 +226,11 @@ export const InternalTextInputElement = ({
 	readOnly,
 	type,
 	value,
+	className,
 	...rest
 }: Pick<
 	TextInputProps,
-	"readOnly" | "disabled" | "placeholder" | "value" | "type"
+	"readOnly" | "disabled" | "placeholder" | "value" | "type" | "className"
 > & {
 	id: string;
 	inputRef: RefObject<HTMLInputElement>;
@@ -237,7 +238,7 @@ export const InternalTextInputElement = ({
 }) => (
 	<input
 		aria-describedby={hasHelperText ? `${id}-description` : undefined}
-		className={clsx("neo-input", readOnly && "neo-input-readonly")}
+		className={clsx("neo-input", className, readOnly && "neo-input-readonly")}
 		disabled={disabled}
 		id={id}
 		placeholder={placeholder}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -18,6 +18,7 @@ import {
 } from "utils";
 
 import "./TextInput_shim.css";
+import { type ExternalLabelProps, useLabel } from "components/Label";
 
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
 	ariaLabelPasswordHide?: string;
@@ -30,7 +31,7 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
 	error?: boolean;
 	helperText?: string;
 	inline?: boolean;
-	label?: string;
+	label?: string | ExternalLabelProps;
 	placeholder?: string;
 	readOnly?: boolean;
 	required?: boolean;
@@ -123,7 +124,7 @@ export const TextInput = ({
 			required={required}
 			inline={inline}
 		>
-			{label && <label htmlFor={id}>{label}</label>}
+			{label && useLabel(label, id)}
 
 			{readOnly ? (
 				<InternalTextInputElement

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, Story } from "@storybook/react";
 import { Avatar } from "components/Avatar";
 import { Button } from "components/Button";
 
+import { Icon } from "components/Icon";
 import { Tooltip, type TooltipProps } from "./";
 
 export default {
@@ -16,6 +17,17 @@ export const Default = () => (
 	</Tooltip>
 );
 
+export const IconTooltip = () => (
+	<Tooltip label="This is the ID of the workflow.">
+		<Icon
+			role="button"
+			tabIndex={0}
+			icon="info"
+			aria-label="workflow id"
+			size="sm"
+		/>
+	</Tooltip>
+);
 const Template: Story<TooltipProps> = ({ children, ...rest }: TooltipProps) => (
 	<Tooltip {...rest}>
 		{children || <Button variant="primary">button text</Button>}


### PR DESCRIPTION
[TextInput Label with Icon](https://deploy-preview-572--neo-react-library-storybook.netlify.app/?path=/story/components-text-input--label-with-icon)
[Switches Label with Icon, scroll the bottom of the story](https://deploy-preview-572--neo-react-library-storybook.netlify.app/?path=/story/components-switch--default)
[Figma reference: TextInput](https://www.figma.com/design/SQHQlIhFHWCjngHZOnK8MH/Web-Components-2.0?m=auto&node-id=1-144&t=VeWAoZcNyrp0nsA6-1)
[Figma reference: Label](https://www.figma.com/design/SQHQlIhFHWCjngHZOnK8MH/Web-Components-2.0?m=auto&node-id=907-311198&t=VeWAoZcNyrp0nsA6-1)
[Figma reference: Kin Ye](https://www.figma.com/design/n1vWAQ0pgib4s7M1uig987/05---NGM---Features---Contact-Center?node-id=1865-112249&node-type=canvas&t=xRu03FCUulgxYdLQ-0)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`


`@avaya-dux/dux-design`: 
- please check both visuals and keyboard interaction with the Icon in both TextInput and Switch stories lined above;

`@avaya-dux/dux-devs`: 
- created an internal Label component, not exported externally as no use cases yet;
- support both TextInput and Switch component;
- allow passing custom classes to TextInput;

<img width="1513" alt="Screenshot 2024-10-23 at 11 25 50 AM" src="https://github.com/user-attachments/assets/1aaac74b-3085-48b9-8bb3-17e088ac07cd">
<img width="341" alt="Screenshot 2024-10-23 at 11 25 34 AM" src="https://github.com/user-attachments/assets/71da6e5a-9b7c-4796-9602-c143a0c6d2a4">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a `Label` component for enhanced label rendering with optional icons.
	- Added `labelIcon` prop to the `Switch` component for icon integration in labels.
	- New `LabelWithIcon` story for the `TextInput` component showcasing labeled icons.
	- Created `IconTooltip` story for the `Tooltip` component with an icon.

- **Bug Fixes**
	- Improved accessibility compliance in the `LabelWithIcon` tests.

- **Documentation**
	- Enhanced Storybook documentation for `Switch`, `TextInput`, and `Tooltip` components with new examples.

- **Style**
	- Added new CSS styles for labels and text inputs to improve layout and visual structure.

- **Chores**
	- Updated version number in `package.json` from `1.4.1` to `1.4.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->