### PR TITLE
NEO-2460 // add `notification` prop to Icon component

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"react-table": "7.8.0"
 	},
 	"devDependencies": {
-		"@avaya/neo": "3.81.18",
+		"@avaya/neo": "3.81.19",
 		"@avaya/neo-icons": "1.8.16",
 		"@biomejs/biome": "1.9.4",
 		"@dnd-kit/core": "6.1.0",

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -75,3 +75,12 @@ AwayStatus.args = {
 	size: "lg",
 	"aria-label": "Testing status away",
 };
+
+export const AvailableWithNotification = Template.bind({});
+AvailableWithNotification.args = {
+	icon: "call",
+	status: "available",
+	size: "lg",
+	notification: true,
+	"aria-label": "Testing status away",
+};

--- a/src/components/Icon/Icon.test.jsx
+++ b/src/components/Icon/Icon.test.jsx
@@ -1,9 +1,9 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 
 import { Icon } from ".";
 
-describe("ExampleComponent", () => {
+describe("Icon Component", () => {
 	it("fully renders without exploding", () => {
 		const { getByTestId } = render(
 			<Icon
@@ -62,5 +62,21 @@ describe("ExampleComponent", () => {
 		const rootElement = getByTestId("neo-icon");
 		expect(rootElement).toBeTruthy();
 		expect(rootElement).toHaveClass(customClassName);
+	});
+
+	it("if `notification` is false, the root element does not have children", () => {
+		const ariaLabel = "available, has notification";
+		render(<Icon icon="save" aria-label={ariaLabel} />);
+
+		const rootElement = screen.getByLabelText(ariaLabel);
+		expect(rootElement.firstChild).toBeNull();
+	});
+
+	it("if `notification` is passed, has a child with a class name: `neo-badge`", () => {
+		const ariaLabel = "available, has notification";
+		render(<Icon icon="save" aria-label={ariaLabel} notification />);
+
+		const rootElement = screen.getByLabelText(ariaLabel);
+		expect(rootElement.firstChild).toHaveClass("neo-badge");
 	});
 });

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -8,6 +8,7 @@ export interface IconProps extends React.BaseHTMLAttributes<HTMLElement> {
 	"aria-label": string;
 	className?: string;
 	icon: IconNamesType;
+	notification?: boolean;
 	size?: SizeType;
 	status?:
 		| "available"
@@ -33,6 +34,7 @@ export interface IconProps extends React.BaseHTMLAttributes<HTMLElement> {
 export const Icon: React.FC<IconProps> = ({
 	className,
 	icon,
+	notification = false,
 	size,
 	status,
 	...rest
@@ -69,7 +71,9 @@ export const Icon: React.FC<IconProps> = ({
 				status !== undefined && `neo-icon-state--${status}`,
 				className,
 			)}
-		/>
+		>
+			{notification && <span className="neo-badge" />}
+		</span>
 	);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
   resolved "https://registry.yarnpkg.com/@avaya/neo-icons/-/neo-icons-1.8.16.tgz#63ab62ae5d884f294e7939adb603ef32453ad637"
   integrity sha512-GZ9eR21i/IyYN17xQDaVdOEywGIfq8o+zOtips9mKCkqvUnumx5ZOqv+h+9UzIr1A9YFRBdqGiPz+fH9zBQPIw==
 
-"@avaya/neo@3.81.18":
-  version "3.81.18"
-  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.81.18.tgz#d493cba226af6cfa596e47b68464eff580fa4e23"
-  integrity sha512-OVOIjrHdMFdY89uL7zzQy4loi5cVej6Gw88PoRiY59lNoVt2ltRvZW0MvJLb83dZAYzE7LubdTXSMzQhVxCzGA==
+"@avaya/neo@3.81.19":
+  version "3.81.19"
+  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.81.19.tgz#50c9a889df2ddb596d76681bad88a07e6e1f580e"
+  integrity sha512-ub5mTmyoaLOwk3wCjnkXyk6zKxa2CK9r3DxZU1+WVd50MWFZRds9UTOc81bwsBhnQW/D06/iCF2zYX3pcaJiCg==
 
 "@aw-web-design/x-default-browser@1.4.126":
   version "1.4.126"


### PR DESCRIPTION
[Link to new Icon story](https://deploy-preview-579--neo-react-library-storybook.netlify.app/?path=/story/components-icon--available-with-notification)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`

Pull latest neo-css and update Icon to utilize the new functionality.


`@avaya-dux/dux-devs`: I'll be updating the stories to our new format in the next PR. This is _only_ to pull in the "notification" badge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `notification` property for the Icon component, enabling conditional rendering of a badge.
	- Added a new story for the Icon component in Storybook showcasing the notification feature.

- **Bug Fixes**
	- Enhanced error handling for missing `aria-label` in the Icon component.

- **Tests**
	- Expanded test coverage for the Icon component to include scenarios related to the new `notification` prop. 

- **Chores**
	- Updated the version of the `@avaya/neo` dependency in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->