### PR TITLE
Icon // improve test, get 100% code coverage

### DIFF
--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { vi } from "vitest";
 
 import { Icon } from ".";
 
@@ -31,17 +32,77 @@ describe("Icon Component", () => {
 		expect(rootElement).toHaveClass(customClassName);
 	});
 
-	it("if `notification` is false, the root element does not have children", () => {
-		render(<Icon icon="save" aria-label={ariaLabel} />);
+	it("throws a `console.error` if `status` is passed with `size` as `sm`", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => null);
+		render(
+			<Icon
+				icon="settings"
+				aria-label={ariaLabel}
+				size="sm"
+				status="inbound"
+			/>,
+		);
 
-		const rootElement = screen.getByLabelText(ariaLabel);
-		expect(rootElement.firstChild).toBeNull();
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
 	});
 
-	it("if `notification` is passed, has a child with a class name: `neo-badge`", () => {
-		render(<Icon icon="save" aria-label={ariaLabel} notification />);
+	it("throws an error if `aria-label` is not passed", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => null); // hide error from console
+		expect(() =>
+			// biome-ignore lint/a11y/useValidAriaValues: testing an invalid value
+			render(<Icon icon="settings" aria-label="" />),
+		).toThrowError(
+			"A descriptive label is required for screen readers to identify the button's purpose",
+		);
+		spy.mockRestore();
+	});
 
-		const rootElement = screen.getByLabelText(ariaLabel);
-		expect(rootElement.firstChild).toHaveClass("neo-badge");
+	describe("renders the correct icon size", () => {
+		it("if `size` is `sm`, has a class name: `neo-icon--small`", () => {
+			render(<Icon icon="save" aria-label={ariaLabel} size="sm" />);
+
+			const rootElement = screen.getByLabelText(ariaLabel);
+			expect(rootElement).toHaveClass("neo-icon--small");
+		});
+
+		it("if `size` is `md`, has a class name: `neo-icon--medium`", () => {
+			render(<Icon icon="save" aria-label={ariaLabel} size="md" />);
+
+			const rootElement = screen.getByLabelText(ariaLabel);
+			expect(rootElement).toHaveClass("neo-icon--medium");
+		});
+
+		it("if `size` is `lg`, has a class name: `neo-icon--large`", () => {
+			render(<Icon icon="save" aria-label={ariaLabel} size="lg" />);
+
+			const rootElement = screen.getByLabelText(ariaLabel);
+			expect(rootElement).toHaveClass("neo-icon--large");
+		});
+
+		it("shows a large icon if `status` is passed with `size` as `lg`", () => {
+			render(
+				<Icon icon="save" aria-label={ariaLabel} size="lg" status="inbound" />,
+			);
+
+			const rootElement = screen.getByLabelText(ariaLabel);
+			expect(rootElement).toHaveClass("neo-icon-state--large");
+		});
+	});
+
+	describe("handles the `notification` prop appropriately", () => {
+		it("if `notification` is false, the root element does not have children", () => {
+			render(<Icon icon="save" aria-label={ariaLabel} />);
+
+			const rootElement = screen.getByLabelText(ariaLabel);
+			expect(rootElement.firstChild).toBeNull();
+		});
+
+		it("if `notification` is passed, has a child with a class name: `neo-badge`", () => {
+			render(<Icon icon="save" aria-label={ariaLabel} notification />);
+
+			const rootElement = screen.getByLabelText(ariaLabel);
+			expect(rootElement.firstChild).toHaveClass("neo-badge");
+		});
 	});
 });

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -4,68 +4,34 @@ import { axe } from "jest-axe";
 import { Icon } from ".";
 
 describe("Icon Component", () => {
-	it("fully renders without exploding", () => {
-		const { getByTestId } = render(
-			<Icon
-				data-testid="neo-icon"
-				icon="settings"
-				aria-label="test"
-				role="figure"
-			/>,
-		);
+	const ariaLabel = "label for testing";
 
-		const rootElement = getByTestId("neo-icon");
+	it("fully renders without exploding", () => {
+		render(<Icon icon="settings" aria-label={ariaLabel} />);
+
+		const rootElement = screen.getByLabelText(ariaLabel);
 		expect(rootElement).toBeTruthy();
 	});
 
 	it("passes basic axe compliance", async () => {
 		const { container } = render(
-			<Icon
-				data-testid="neo-icon"
-				icon="settings"
-				aria-label="test"
-				role="figure"
-			/>,
+			<Icon icon="settings" aria-label={ariaLabel} />,
 		);
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
 
-	it("test for className neo is in place", () => {
-		const iconClassName = "neo-icon-save";
-		const { getByTestId } = render(
-			<Icon
-				data-testid="neo-icon"
-				icon="save"
-				aria-label="test"
-				role="figure"
-			/>,
-		);
-
-		const rootElement = getByTestId("neo-icon");
-		expect(rootElement).toBeTruthy();
-		expect(rootElement).toHaveClass(iconClassName);
-	});
-
-	it("use a custom className ", () => {
+	it("allows custom class names ", () => {
 		const customClassName = "ha-ha css-class-name-test";
-		const { getByTestId } = render(
-			<Icon
-				data-testid="neo-icon"
-				icon="save"
-				aria-label="test"
-				role="figure"
-				className={customClassName}
-			/>,
+		render(
+			<Icon icon="save" aria-label={ariaLabel} className={customClassName} />,
 		);
 
-		const rootElement = getByTestId("neo-icon");
-		expect(rootElement).toBeTruthy();
+		const rootElement = screen.getByLabelText(ariaLabel);
 		expect(rootElement).toHaveClass(customClassName);
 	});
 
 	it("if `notification` is false, the root element does not have children", () => {
-		const ariaLabel = "available, has notification";
 		render(<Icon icon="save" aria-label={ariaLabel} />);
 
 		const rootElement = screen.getByLabelText(ariaLabel);
@@ -73,7 +39,6 @@ describe("Icon Component", () => {
 	});
 
 	it("if `notification` is passed, has a child with a class name: `neo-badge`", () => {
-		const ariaLabel = "available, has notification";
 		render(<Icon icon="save" aria-label={ariaLabel} notification />);
 
 		const rootElement = screen.getByLabelText(ariaLabel);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,6 +1,9 @@
 import clsx from "clsx";
 
-import { type IconNamesType, getIconClass } from "utils/icons";
+import { handleAccessbilityError } from "utils";
+
+import type { IconNamesType } from "utils/icons";
+import { getIconClass } from "utils/icons";
 
 // import { SizeType } from "utils/size"; TODO https://jira.forge.avaya.com/browse/NEO-645
 type SizeType = "sm" | "md" | "lg";
@@ -40,7 +43,7 @@ export const Icon: React.FC<IconProps> = ({
 	...rest
 }: IconProps) => {
 	if (!rest["aria-label"]) {
-		console.error(
+		handleAccessbilityError(
 			"A descriptive label is required for screen readers to identify the button's purpose",
 		);
 	}
@@ -67,8 +70,8 @@ export const Icon: React.FC<IconProps> = ({
 			{...rest}
 			className={clsx(
 				icon && getIconClass(icon),
-				status !== undefined && "neo-icon-state",
 				sizing,
+				status !== undefined && "neo-icon-state",
 				status !== undefined && `neo-icon-state--${status}`,
 				className,
 			)}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -44,6 +44,7 @@ export const Icon: React.FC<IconProps> = ({
 			"A descriptive label is required for screen readers to identify the button's purpose",
 		);
 	}
+
 	if (status !== undefined && size === "sm") {
 		console.error(
 			"Status icons are not supported in small size. Size set to medium.",

--- a/src/components/IconButton/IconButton.test.jsx
+++ b/src/components/IconButton/IconButton.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { vi } from "vitest";
 
 import { IconButton } from "./IconButton";
 
@@ -34,7 +35,9 @@ describe("Button", () => {
 	});
 
 	it("throws an error if `aria-label` is not passed", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => null); // hide error from console
 		expect(() => render(<IconButton icon="save" shape="square" />)).toThrow();
+		spy.mockRestore();
 	});
 
 	it("should respect the 'badge' prop", () => {


### PR DESCRIPTION
**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] ~tagged `@avaya-dux/dux-design` if any visual changes have occurred~
- [x] tagged `@avaya-dux/dux-devs`


`@avaya-dux/dux-devs`: getting us to 100% code coverage 
![Screenshot 2024-10-29 at 14 26 23](https://github.com/user-attachments/assets/c2bda035-6a38-44da-97fb-c071695e0027)
