### PR TITLE
Removed unintentional margin on IconButton Spinner animation

### DIFF
--- a/src/components/IconButton/IconButton_shim.css
+++ b/src/components/IconButton/IconButton_shim.css
@@ -27,3 +27,7 @@
 	right: 6px;
 	top: 11px;
 }
+
+.neo-btn.neo-icon-btn > .neo-spinner {
+	margin: 0px;
+}


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-591--neo-react-library-storybook.netlify.app/?path=/docs/components-iconbutton--docs)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [ ] tagged `@avaya-dux/dux-devs`

Fixed bug in IconButton styles that caused Spinner animation to be misaligned due to extra margin

**EXAMPLE FUNCTIONALITY GIF:**

Before:
<img width="184" alt="Screenshot 2024-11-22 at 4 20 41 PM" src="https://github.com/user-attachments/assets/335f1f23-712e-4eb1-a97d-85ebf06a077f">

After:
<img width="180" alt="Screenshot 2024-11-22 at 4 19 10 PM" src="https://github.com/user-attachments/assets/e87f8a83-bc2c-4a16-ae9c-85149beb46c2">
