### PR TITLE
Add readonly prop to Switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"react-table": "7.8.0"
 	},
 	"devDependencies": {
-		"@avaya/neo": "3.81.23",
+		"@avaya/neo": "3.82.0",
 		"@avaya/neo-icons": "1.8.18",
 		"@biomejs/biome": "1.9.4",
 		"@dnd-kit/core": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
 		"react-table": "7.8.0"
 	},
 	"devDependencies": {
-		"@avaya/neo": "3.82.0",
-		"@avaya/neo-icons": "1.8.18",
+		"@avaya/neo": "3.83.0",
+		"@avaya/neo-icons": "1.8.19",
 		"@biomejs/biome": "1.9.4",
 		"@dnd-kit/core": "6.3.1",
 		"@dnd-kit/modifiers": "9.0.0",

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -57,6 +57,10 @@ const DirectionTemplate: Story<DirectionTemplateProps> = ({
 				<Switch disabled defaultChecked>
 					Disabled Checked
 				</Switch>
+				<Switch readonly>Readonly Unchecked</Switch>
+				<Switch readonly defaultChecked>
+					Readonly Checked
+				</Switch>
 				<Switch defaultChecked dir="rtl">
 					Label fixed on left
 				</Switch>

--- a/src/components/Switch/Switch.test.jsx
+++ b/src/components/Switch/Switch.test.jsx
@@ -65,12 +65,20 @@ describe("Switch Component", () => {
 		});
 	});
 
-	describe("applies `readonly` classname appropriately", () => {
-		it("applies the `readonly` class when that prop is passed", async () => {
+	describe("applies `readonly` classname and behavior appropriately", () => {
+		it("applies the `readonly` class & prevents state change when that prop is passed", async () => {
 			render(<Switch readonly>{labelText}</Switch>);
 
 			const inputLabel = screen.getByText(labelText);
 			expect(inputLabel).toHaveClass("neo-switch--readonly");
+
+			const input = screen.getByRole("switch");
+			expect(input).toHaveAttribute("readonly", "");
+			expect(input).not.toBeChecked();
+
+			await user.click(input);
+			expect(input).toHaveAttribute("readonly", "");
+			expect(input).not.toBeChecked();
 		});
 	});
 

--- a/src/components/Switch/Switch.test.jsx
+++ b/src/components/Switch/Switch.test.jsx
@@ -65,6 +65,15 @@ describe("Switch Component", () => {
 		});
 	});
 
+	describe("applies `readonly` classname appropriately", () => {
+		it("applies the `readonly` class when that prop is passed", async () => {
+			render(<Switch readonly>{labelText}</Switch>);
+
+			const inputLabel = screen.getByText(labelText);
+			expect(inputLabel).toHaveClass("neo-switch--readonly");
+		});
+	});
+
 	describe("applies the `multiline` and `disabled` classes appropriately", () => {
 		it("applies the `multiline` and `disabled` classes when those props are passed", () => {
 			const { container } = render(

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -35,6 +35,7 @@ export const Switch = ({
 	onChange,
 	dir,
 	labelIcon,
+	readonly,
 	...rest
 }: SwitchProps) => {
 	const generatedId = useId();
@@ -62,6 +63,7 @@ export const Switch = ({
 					"neo-switch",
 					multiline && "neo-switch--multiline",
 					disabled && "neo-switch--disabled",
+					readonly && "neo-switch--readonly",
 				)}
 				htmlFor={id}
 				icon={labelIcon}

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -74,8 +74,14 @@ export const Switch = ({
 					type="checkbox"
 					role="switch"
 					aria-checked={rest.checked}
+					aria-readonly={readonly}
+					readOnly={readonly}
 					onChange={(event) => {
-						onChange?.(event, event.target.checked);
+						if (!readonly) {
+							onChange?.(event, event.target.checked);
+						} else {
+							event.preventDefault();
+						}
 					}}
 					{...rest}
 				/>

--- a/src/components/Switch/SwitchTypes.ts
+++ b/src/components/Switch/SwitchTypes.ts
@@ -22,4 +22,5 @@ export interface SwitchProps
 	onChange?: ChangeEventHandler<HTMLInputElement> | SwitchChangeHandler;
 	children?: ReactNode;
 	labelIcon?: LabelIconProps;
+	readonly?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,15 +28,15 @@
   resolved "https://registry.yarnpkg.com/@atomic-layout/core/-/core-0.14.1.tgz#3d69be5f79775f11b8008f18bc603b04a2141ccd"
   integrity sha512-o5nhk/1djuKzB20C2LSOuetTDytsbGg4c0UfxXkq1pqoaN3hKJcHPYF9nV+p6+P5CWqNBaaJddZ32OsFSppULQ==
 
-"@avaya/neo-icons@1.8.18":
-  version "1.8.18"
-  resolved "https://registry.yarnpkg.com/@avaya/neo-icons/-/neo-icons-1.8.18.tgz#f7befd1ea9ebb34e466f951820bca46e9b76a8e0"
-  integrity sha512-tl5dEdtqQdvDc3bNkoIzhwMqMQH5nuOam9h3LkiSLgOyDOPr2BfAwVQtD8dALmxDcLBe//o+a+1WRhyTX7u5aA==
+"@avaya/neo-icons@1.8.19":
+  version "1.8.19"
+  resolved "https://registry.yarnpkg.com/@avaya/neo-icons/-/neo-icons-1.8.19.tgz#ca56f63f720d19aa465b074e373b1ee2d21f3e26"
+  integrity sha512-cxx2nO7gs8LtVauV0FoW9wzoeUlX0SlkI5tDZr0o2/PtqaYSx7nHngkGU88TBe8x7ha0irdRIJbtvzByJy5SFw==
 
-"@avaya/neo@3.82.0":
-  version "3.82.0"
-  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.82.0.tgz#4cca01a93b29d157dc9fc1ae5424a851e972a99b"
-  integrity sha512-QX25FYQ4eyMYajCIHSoIkxrPaplukrVShCSUyyELTamlG4CxglN0PfvNMTISj3e9slbQINsDMAxSUGLk8wSOzQ==
+"@avaya/neo@3.83.0":
+  version "3.83.0"
+  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.83.0.tgz#08bf3ad516554f392e845dd5c49cde80afab1212"
+  integrity sha512-G89HCbMz7/wi3Up8+VkvA65sPGCJxV+Ei7cS+QDF1pU/ROH3TaPu0+08ipkZMSfQKu3/TEcJENq8RbG0QZeZqA==
 
 "@aw-web-design/x-default-browser@1.4.126":
   version "1.4.126"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
   resolved "https://registry.yarnpkg.com/@avaya/neo-icons/-/neo-icons-1.8.18.tgz#f7befd1ea9ebb34e466f951820bca46e9b76a8e0"
   integrity sha512-tl5dEdtqQdvDc3bNkoIzhwMqMQH5nuOam9h3LkiSLgOyDOPr2BfAwVQtD8dALmxDcLBe//o+a+1WRhyTX7u5aA==
 
-"@avaya/neo@3.81.23":
-  version "3.81.23"
-  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.81.23.tgz#1a4364aee4e075d80b87c72e9ecd90f443c96627"
-  integrity sha512-E2yhYZ0Egz5FtrjviNAS1IVwib/GCAW0GZ097QpQjHG+Op9mhhXEw2BDsoVeccn6zVv9Zw/FC5485f2c7sQHzg==
+"@avaya/neo@3.82.0":
+  version "3.82.0"
+  resolved "https://registry.yarnpkg.com/@avaya/neo/-/neo-3.82.0.tgz#4cca01a93b29d157dc9fc1ae5424a851e972a99b"
+  integrity sha512-QX25FYQ4eyMYajCIHSoIkxrPaplukrVShCSUyyELTamlG4CxglN0PfvNMTISj3e9slbQINsDMAxSUGLk8wSOzQ==
 
 "@aw-web-design/x-default-browser@1.4.126":
   version "1.4.126"


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-603--neo-react-library-storybook.netlify.app/?path=/docs/components-switch--docs)
[Link to Figma reference](https://www.figma.com/design/SQHQlIhFHWCjngHZOnK8MH/Web-Components-2.0?node-id=1-141&p=f&t=wCy0QVNKYjHjkXYp-0)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY Add props to display readonly styling to Switch Component

**EXAMPLE IMAGE(S):**
<img width="275" alt="Screenshot 2025-01-15 at 1 45 34 PM" src="https://github.com/user-attachments/assets/b43e26b9-f20f-4d1e-8d39-e4586fdd8c71" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `readonly` prop to Switch component, allowing for read-only state visualization.
  - Introduced new Switch examples in Storybook for "Readonly Unchecked" and "Readonly Checked" states.

- **Dependency Updates**
  - Updated `@avaya/neo` dependency to version 3.83.0.
  - Updated `@avaya/neo-icons` dependency to version 1.8.19.

- **Tests**
  - Added test coverage for Switch component's read-only state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->