### PR TITLE
Add prop to make Drawer scrim optional; added explicit 'type' attribute to Buttons in Drawer header to ensure correct behaviour when used in Form elements

### DIFF
--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -63,6 +63,44 @@ export const InformativeDrawer: Story = {
 	},
 };
 
+export const DrawerWithoutScrim: Story = {
+	render: () => {
+		const [defaultDrawerOpen, setDefaultDrawerOpen] = useState(false);
+
+		return (
+			<main>
+				<section
+					style={{
+						display: "flex",
+						justifyContent: "space-between",
+						marginBottom: "1rem",
+					}}
+				>
+					<Button onClick={() => setDefaultDrawerOpen(!defaultDrawerOpen)}>
+						Open Drawer Without Scrim
+					</Button>
+				</section>
+
+				<Drawer
+					open={defaultDrawerOpen}
+					onClose={() => setDefaultDrawerOpen(false)}
+					title="Title of Drawer"
+					hasScrim={false}
+				>
+					<div style={{ height: "100%", width: "100%" }}>
+						<p>This Drawer does not have a scrim</p>
+						<br />
+						<p>
+							Dismiss the Drawer by selecting the ‘Clear’ icon at the top right
+							next to the title.
+						</p>
+					</div>
+				</Drawer>
+			</main>
+		);
+	},
+};
+
 // This story showcases how to use the default Cancel and Apply buttons.
 export const WithDefaultButtons: Story = {
 	render: () => {

--- a/src/components/Drawer/Drawer.test.jsx
+++ b/src/components/Drawer/Drawer.test.jsx
@@ -51,6 +51,12 @@ describe("Drawer", () => {
 		expect(results).toHaveNoViolations();
 	});
 
+	it("does not render scrim when hasScrim prop is set to false", async () => {
+		render(<Drawer title="drawer title" />);
+		render(<Drawer title="drawer title" hasScrim={false} />);
+		expect(screen.queryAllByTestId("scrim")).toHaveLength(1);
+	});
+
 	describe("`open` functionality", () => {
 		it("when `open={true}`, a Drawer's contents _are_ visible", () => {
 			render(<Drawer open={true} title="drawer title" />);

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -45,6 +45,7 @@ export interface BaseDrawerProps
 	onCancel?: (e: MouseEvent<HTMLButtonElement>) => void;
 	onApply?: (e: MouseEvent<HTMLButtonElement>) => void;
 	disableApplyButton?: boolean;
+	hasScrim?: boolean;
 	closeOnScrimClick?: boolean;
 	ref?: React.Ref<HTMLDivElement>;
 	open?: boolean;
@@ -140,6 +141,7 @@ const BasicDrawer = ({
 	onCancel,
 	onApply,
 	disableApplyButton,
+	hasScrim = true,
 	closeOnScrimClick,
 	open,
 	title,
@@ -161,6 +163,7 @@ const BasicDrawer = ({
 	onCancel?: (e: MouseEvent<HTMLButtonElement>) => void;
 	onApply?: (e: MouseEvent<HTMLButtonElement>) => void;
 	disableApplyButton: boolean;
+	hasScrim?: boolean;
 	closeOnScrimClick: boolean;
 	open: boolean;
 	title?: string | JSX.Element;
@@ -197,6 +200,7 @@ const BasicDrawer = ({
 						<div className="neo-drawer__header--left">
 							{onBack !== undefined && (
 								<IconButton
+									type="button"
 									onClick={onBack}
 									variant="tertiary"
 									shape="square"
@@ -211,6 +215,7 @@ const BasicDrawer = ({
 						<div className="neo-drawer__header--right">
 							{onClose !== undefined && onCancel === undefined && (
 								<IconButton
+									type="button"
 									onClick={onClose}
 									variant="tertiary"
 									shape="square"
@@ -227,7 +232,7 @@ const BasicDrawer = ({
 					{(onCancel || onApply) && (
 						<div className="neo-drawer__actions">
 							{onCancel && (
-								<Button onClick={onCancel} key="cancel-btn" variant="secondary">
+								<Button type="button" onClick={onCancel} key="cancel-btn" variant="secondary">
 									{translations?.cancel}
 								</Button>
 							)}
@@ -245,11 +250,12 @@ const BasicDrawer = ({
 					)}
 				</div>
 			</FocusLock>
-			{open && (
+			{hasScrim && open && (
 				<div
 					onKeyDown={onKeyDownScrimHandler}
 					onClick={closeOnScrimClick ? onClose : undefined}
 					className="neo-drawer__scrim"
+					data-testid="scrim"
 				/>
 			)}
 		</div>

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -232,7 +232,12 @@ const BasicDrawer = ({
 					{(onCancel || onApply) && (
 						<div className="neo-drawer__actions">
 							{onCancel && (
-								<Button type="button" onClick={onCancel} key="cancel-btn" variant="secondary">
+								<Button
+									type="button"
+									onClick={onCancel}
+									key="cancel-btn"
+									variant="secondary"
+								>
 									{translations?.cancel}
 								</Button>
 							)}


### PR DESCRIPTION
[Drawer without Scrim](https://deploy-preview-613--neo-react-library-storybook.netlify.app/?path=/story/components-drawer--drawer-without-scrim)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY: This PR adds a `hasScrim` prop to the `Drawer` Component to make rendering a scrim element optional. It also adds explicit `type` attributes to all the `Button` Components in the Drawer which are not intended to submit information, in order to avoid the default behaviour of attributing `submit` type to all button elements inside of a form.