### PR TITLE
Added prop to Notification to allow user to pass in value for aria-live attribute, tweaked styling of PopUpManager to stack popups vertically

### DIFF
--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -87,6 +87,7 @@ export const Notification = ({
 	showTimestamp = true,
 	isElevated = false,
 	isInline = false,
+	ariaLive = "polite",
 	occurences = 0,
 	locale = "en-US",
 	translations,
@@ -177,7 +178,7 @@ export const Notification = ({
 				isElevated && "neo-notification__elevated",
 			)}
 			role="alert"
-			aria-live="polite"
+			aria-live={ariaLive}
 		>
 			<div
 				role="img"

--- a/src/components/Notification/NotificationTypes.tsx
+++ b/src/components/Notification/NotificationTypes.tsx
@@ -19,6 +19,7 @@ type AtLeastOneProps =
 	| { header?: string; description: string };
 
 type CommonProps = {
+	ariaLive?: React.AriaAttributes["aria-live"];
 	showTimestamp?: boolean;
 	isElevated?: boolean;
 	isInline?: boolean;

--- a/src/components/Notification/stories/Notification-5Notify.stories.tsx
+++ b/src/components/Notification/stories/Notification-5Notify.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta } from "@storybook/react";
+import { useEffect } from "react";
+
+import { Button } from "components/Button";
+
+import { removePopupManagerContainer, usePopup } from "components/PopupManager";
+import { type NonEventNotificationProps, Notification } from "../..";
+
+export default {
+	title: "Components/Notification/Notify",
+} as Meta<NonEventNotificationProps>;
+
+export const Notify = () => {
+	const { mounted, notify } = usePopup("notify-me");
+
+	useEffect(() => {
+		return () => {
+			removePopupManagerContainer();
+		};
+	}, []);
+
+	return !mounted ? (
+		<div>not ready</div>
+	) : (
+		<div>
+			<Button
+				data-testid="neo-button-notify"
+				id="btn-notify"
+				variant="primary"
+				onClick={() => {
+					notify({
+						node: (
+							<Notification
+								type="alert"
+								header="Alert"
+								description="This is an alert."
+							/>
+						),
+						width: "375px",
+					});
+				}}
+			>
+				Notify Me
+			</Button>
+		</div>
+	);
+};
+
+// notify = (options: NotificationOptions) => {
+//     logger.debug("notify in popup manager called with ", options.id);
+//     PopupManager.counter += 1;
+//     const id = options.id ?? PopupManager.counter;
+//     const position = options.position ?? "top";
+//     const notification = {
+//         id,
+//         node: options.node,
+//         position,
+//         width: options.width,
+//     };
+//     logger.debug(
+//         `notify: state before update at ${position} is `,
+//         this.state.positions[position],
+//     );
+//     this.addPopup(position, notification);
+//     logger.debug("notify returns ", { id, position });
+//     return { id, position };
+// };

--- a/src/components/Notification/stories/Notification-5Notify.stories.tsx
+++ b/src/components/Notification/stories/Notification-5Notify.stories.tsx
@@ -34,6 +34,7 @@ export const Notify = () => {
 								type="alert"
 								header="Alert"
 								description="This is an alert."
+								ariaLive="assertive"
 							/>
 						),
 						width: "375px",

--- a/src/components/Notification/stories/Notification-5Notify.stories.tsx
+++ b/src/components/Notification/stories/Notification-5Notify.stories.tsx
@@ -11,13 +11,33 @@ export default {
 } as Meta<NonEventNotificationProps>;
 
 export const Notify = () => {
-	const { mounted, notify } = usePopup("notify-me");
+	const { mounted, notify, remove } = usePopup("notify-me");
 
 	useEffect(() => {
 		return () => {
 			removePopupManagerContainer();
 		};
 	}, []);
+
+	function renderNotification() {
+		const { id, position } = notify({
+			node: (
+				<Notification
+					actions={{
+						closable: {
+							onClick: () => remove(id, position),
+							"aria-label": "Click this button will close this notification",
+						},
+					}}
+					type="alert"
+					header="Alert"
+					description="This is an alert."
+					ariaLive="assertive"
+				/>
+			),
+			width: "375px",
+		});
+	}
 
 	return !mounted ? (
 		<div>not ready</div>
@@ -28,17 +48,7 @@ export const Notify = () => {
 				id="btn-notify"
 				variant="primary"
 				onClick={() => {
-					notify({
-						node: (
-							<Notification
-								type="alert"
-								header="Alert"
-								description="This is an alert."
-								ariaLive="assertive"
-							/>
-						),
-						width: "375px",
-					});
+					renderNotification();
 				}}
 			>
 				Notify Me
@@ -46,23 +56,3 @@ export const Notify = () => {
 		</div>
 	);
 };
-
-// notify = (options: NotificationOptions) => {
-//     logger.debug("notify in popup manager called with ", options.id);
-//     PopupManager.counter += 1;
-//     const id = options.id ?? PopupManager.counter;
-//     const position = options.position ?? "top";
-//     const notification = {
-//         id,
-//         node: options.node,
-//         position,
-//         width: options.width,
-//     };
-//     logger.debug(
-//         `notify: state before update at ${position} is `,
-//         this.state.positions[position],
-//     );
-//     this.addPopup(position, notification);
-//     logger.debug("notify returns ", { id, position });
-//     return { id, position };
-// };

--- a/src/components/PopupManager/PopupUtils.ts
+++ b/src/components/PopupManager/PopupUtils.ts
@@ -27,7 +27,7 @@ export const getContainerStyle = (
 		display: "flex",
 		flexDirection: "column",
 		flexWrap: position.includes("right") ? "wrap-reverse" : "wrap",
-		maxHeight: "25vh",
+		width: "fit-content",
 		margin,
 		top,
 		bottom,


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-614--neo-react-library-storybook.netlify.app/?path=/docs/components-notification-notify--docs)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY This PR adds an optional `ariaLive` prop to the Notification Component to allow the user to pass in their desired value for the `aria-live` attribute. The default value is "polite." This PR also tweaks the styling on the `PopUpManager` Component to stack popup elements vertically instead of horizontally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced notifications now offer customizable accessibility announcements for improved screen reader support.
  - An interactive demonstration has been added to showcase the updated notification behavior.

- **Style**
  - Popup layouts have been refined to automatically adjust their width based on content, ensuring a more adaptable display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->