### PR TITLE
Removed unnecessary renders in Single Select Combobox Component, updated Cypress test as necessary

### DIFF
--- a/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
+++ b/src/components/Select/InternalComponents/SingleSelectSearchable.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import type { UseComboboxReturnValue } from "downshift";
 import log from "loglevel";
-import { type FocusEvent, useContext, useEffect, useMemo } from "react";
+import { type FocusEvent, useContext } from "react";
 
 import { Keys } from "utils";
 
@@ -38,27 +38,16 @@ export const SingleSelectSearchable = () => {
 		reset,
 		selectItem,
 		highlightedIndex,
-		setInputValue,
 	} = downshiftProps as UseComboboxReturnValue<SelectOptionProps>;
 	const { "aria-expanded": toggleAriaExpanded, ...restToggleProps } =
 		getToggleButtonProps();
-	const { id, onKeyDown, ref, ...restInputProps } = getInputProps();
-
-	const selectedAsInputValue = useMemo(
-		() => selectedItems[0]?.children ?? "",
-		[selectedItems],
-	);
+	const { id, onKeyDown, ref, value, ...restInputProps } = getInputProps();
 
 	logger.debug({
 		value: restInputProps.value,
 		inputValue,
-		selected: selectedAsInputValue,
 		creatable,
 	});
-
-	useEffect(() => {
-		setInputValue(selectedAsInputValue);
-	}, [selectedAsInputValue, setInputValue]);
 
 	return (
 		<div
@@ -81,6 +70,7 @@ export const SingleSelectSearchable = () => {
 				<span className="neo-multiselect__padded-container">
 					<input
 						{...restInputProps}
+						value={value}
 						ref={ref}
 						className="neo-input"
 						disabled={disabled}
@@ -125,7 +115,7 @@ export const SingleSelectSearchable = () => {
 						id={id}
 						readOnly
 						tabIndex={-1}
-						value={selectedAsInputValue}
+						value={value}
 					/>
 				</span>
 			</span>

--- a/src/components/Select/Select.cy.tsx
+++ b/src/components/Select/Select.cy.tsx
@@ -69,7 +69,7 @@ describe("Single Select Searchable Scrolling Tests", () => {
 		cy.get("span")
 			.first()
 			.type(
-				"{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}",
+				"{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}",
 			);
 		cy.get("[role='listbox']")
 			.first()

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -605,6 +605,33 @@ export const SmallSelects = () => {
 	);
 };
 
+export const FlickerTest = () => {
+	const [isEditing, setIsEditing] = useState(false);
+
+	const numberOfSelects = [1, 2, 3, 4, 5];
+
+	return (
+		<div>
+			<Button onClick={() => setIsEditing(!isEditing)}>Toggle</Button>
+
+			{numberOfSelects.map((_, index) =>
+				isEditing ? (
+					<Select key={index} aria-label="df" searchable>
+						<SelectOption selected value={"Hello"}>
+							Hello
+						</SelectOption>
+						<SelectOption value={"Goodbye"}>Goodbye</SelectOption>
+					</Select>
+				) : (
+					<p key={index} style={{ height: 28, margin: "8px 13px" }}>
+						Hello View mode
+					</p>
+				),
+			)}
+		</div>
+	);
+};
+
 export const InlineCustomWidths = () => {
 	return (
 		<>

--- a/src/components/Select/utils/useDownshift.ts
+++ b/src/components/Select/utils/useDownshift.ts
@@ -36,13 +36,16 @@ const DownshiftWithComboboxProps = (
 	return useCombobox({
 		items: filteredOptions,
 		id: selectId,
-		stateReducer: (_, actionAndChanges) => {
+		initialSelectedItem: selectedItems[0],
+		stateReducer: (state, actionAndChanges) => {
 			const { changes, type } = actionAndChanges;
 			const isOpen = changes.isOpen ? !(disabled || loading) : false;
 			const highlightedIndex = changes.selectedItem
 				? options.indexOf(changes.selectedItem)
 				: -1;
 			logger.debug({ isOpen, type, changes });
+			console.log(type, state);
+			console.log(changes);
 			switch (type) {
 				case useCombobox.stateChangeTypes.ToggleButtonClick:
 					setFilteredOptions([...options]);


### PR DESCRIPTION
[Link to updated components in Deploy Preview](https://deploy-preview-628--neo-react-library-storybook.netlify.app/?path=/story/components-select--flicker-test)

**Before tagging the team for a review, I have done the following:**

- [x] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [x] reviewed my code changes
- [x] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [x] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [x] added any important information to this PR (description, images, GIFs, ect.)
- [x] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [x] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [x] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY Fixed issue where unnecessary prop changes were causing additional re-renders that caused the searchable `Select` Component to flicker when the default value `" "` was changed after initial render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the selection input behavior for a more intuitive and responsive display.
- **New Features**
	- Introduced an interactive view that allows toggling between edit and view modes in selection components.
- **Tests**
	- Updated user interaction tests to provide smoother navigation through selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->