### PR TITLE
Added prop to set Select width to 'fit-content'

### DIFF
--- a/src/components/NeoInputWrapper/NeoInputWrapper_shim.css
+++ b/src/components/NeoInputWrapper/NeoInputWrapper_shim.css
@@ -1,0 +1,3 @@
+.neo--fit-content-width .neo-multiselect__content {
+	width: fit-content;
+}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -632,6 +632,27 @@ export const FlickerTest = () => {
 	);
 };
 
+export const FitToContentWidths = () => {
+	return (
+		<>
+			<Sheet
+				title="Width set to 'fit-content' via 'FitToContentWidth' prop"
+				style={{ width: 1000 }}
+			>
+				<Form inline>
+					<Select label="Select a favorite food" fitToContentWidth>
+						{fruitOptions}
+					</Select>
+
+					<Select label="Select a few nice foods" multiple fitToContentWidth>
+						{fruitOptions}
+					</Select>
+				</Form>
+			</Sheet>
+		</>
+	);
+};
+
 export const InlineCustomWidths = () => {
 	return (
 		<>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import {
 	Children,
 	type ReactElement,
@@ -82,6 +83,7 @@ export const Select = (props: SelectProps) => {
 		value,
 		size = "md",
 		style,
+		fitToContentWidth,
 	} = props;
 
 	const generatedId = useId();
@@ -205,7 +207,10 @@ export const Select = (props: SelectProps) => {
 
 	return (
 		<NeoInputWrapper
-			wrapperClassName={className}
+			wrapperClassName={clsx(
+				fitToContentWidth && "neo--fit-content-width",
+				className,
+			)}
 			disabled={disabled || loading}
 			error={errorList.length > 0}
 			required={required}

--- a/src/components/Select/utils/SelectTypes.tsx
+++ b/src/components/Select/utils/SelectTypes.tsx
@@ -39,5 +39,6 @@ export type SelectProps = {
 	collapse?: boolean;
 	value?: string | string[];
 	size?: SizeTypeSelect;
+	fitToContentWidth?: boolean;
 	style?: React.CSSProperties;
 } & LabelOrAriaLabelProps;


### PR DESCRIPTION
[Link to updated components in Deploy Preview](UPDATEMEWITHALINK)
[Link to Figma reference](UPDATEMEWITHALINK)

**Before tagging the team for a review, I have done the following:**

- [ ] run `yarn all` locally: ensures that all tests pass, formatting is done, types pass, and builds pass
- [ ] reviewed my code changes
- [ ] updated the Deploy Preview link at the top of this PR (or remove it if not applicable)
- [ ] updated the Figma referense link at the top of this PR (or remove it if not applicable)
- [ ] added any important information to this PR (description, images, GIFs, ect.)
- [ ] done an accessibility check on my work (tested with Chrome's `axe Dev Tools`, Mac's VoiceOver, etc.)
- [ ] tagged `@avaya-dux/dux-design` if any visual changes have occurred
- [ ] tagged `@avaya-dux/dux-devs`

ADD PR SUMMARY (should be brief, one sentence if possible)

`@avaya-dux/dux-design`: ADD DESIGN SPECIFIC BRIEF DESCRIPTION

- first focus point
- second focus point
- "not in scope" point one
- "not in scope" point two

`@avaya-dux/dux-devs`: ADD DEV SPECIFIC BRIEF DESCRIPTION

- first focus point
- second focus point
- "not in scope" point one
- "not in scope" point two

**EXAMPLE IMAGE(S):**
[PUT EXAMPLES HERE, such as an image of the new tests, or important use case added by this update]

**EXAMPLE FUNCTIONALITY GIF:**
[PUT EXAMPLE GIF HERE]
